### PR TITLE
Official Gradle Wrapper Validation GitHub Action

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
See: https://github.com/gradle/wrapper-validation-action

One limitation currently exists. This action doesn't support nightly releases.
If you believe that you will ever need to depend upon nightly versions, we'll have an update shortly that allows for this (but this will require changes to `services.gradle.org`).