### PR TITLE
Fix issues with retry of TestNG tests

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/framework/Junit5TestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/framework/Junit5TestFrameworkStrategy.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestFramework;
 import org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.testretry.internal.TestName;
 
@@ -29,6 +30,15 @@ final class Junit5TestFrameworkStrategy extends BaseJunitTestFrameworkStrategy {
 
     @Override
     public TestFramework createRetrying(JvmTestExecutionSpec spec, Test testTask, Set<TestName> failedTests, Instantiator instantiator, ClassLoaderCache classLoaderCache) {
-        return new JUnitPlatformTestFramework(createRetryFilter(spec, failedTests, false));
+        JUnitPlatformTestFramework testFramework = new JUnitPlatformTestFramework(createRetryFilter(spec, failedTests, false));
+        copyTestOptions((JUnitPlatformOptions) testTask.getTestFramework().getOptions(), testFramework.getOptions());
+        return testFramework;
+    }
+
+    private void copyTestOptions(JUnitPlatformOptions source, JUnitPlatformOptions target) {
+        target.setIncludeEngines(source.getIncludeEngines());
+        target.setExcludeEngines(source.getExcludeEngines());
+        target.setIncludeTags(source.getIncludeTags());
+        target.setExcludeTags(source.getExcludeTags());
     }
 }

--- a/plugin/src/main/java/org/gradle/testretry/internal/framework/JunitTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/framework/JunitTestFrameworkStrategy.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestFramework;
 import org.gradle.api.internal.tasks.testing.junit.JUnitTestFramework;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.api.tasks.testing.junit.JUnitOptions;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.testretry.internal.TestName;
 
@@ -29,7 +30,13 @@ final class JunitTestFrameworkStrategy extends BaseJunitTestFrameworkStrategy {
 
     @Override
     public TestFramework createRetrying(JvmTestExecutionSpec spec, Test testTask, Set<TestName> failedTests, Instantiator instantiator, ClassLoaderCache classLoaderCache) {
-        return new JUnitTestFramework(testTask, createRetryFilter(spec, failedTests, true));
+        JUnitTestFramework testFramework = new JUnitTestFramework(testTask, createRetryFilter(spec, failedTests, true));
+        copyTestOptions((JUnitOptions) testTask.getTestFramework().getOptions(), testFramework.getOptions());
+        return testFramework;
     }
 
+    private void copyTestOptions(JUnitOptions source, JUnitOptions target) {
+        target.setIncludeCategories(source.getIncludeCategories());
+        target.setExcludeCategories(source.getExcludeCategories());
+    }
 }

--- a/plugin/src/main/java/org/gradle/testretry/internal/framework/TestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/framework/TestFrameworkStrategy.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.tasks.testing.testng.TestNGTestFramework;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.testretry.internal.TestName;
+import org.gradle.util.GradleVersion;
 
 import java.util.Set;
 
@@ -40,6 +41,10 @@ public interface TestFrameworkStrategy {
         } else {
             throw new UnsupportedOperationException("Unknown test framework: " + testFramework);
         }
+    }
+
+    static boolean gradleVersionIsAtLeast(String version) {
+        return GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version(version)) >= 0;
     }
 
     void removeSyntheticFailures(Set<TestName> nonExecutedFailedTests, TestDescriptorInternal descriptor);

--- a/plugin/src/main/java/org/gradle/testretry/internal/framework/TestNgTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/framework/TestNgTestFrameworkStrategy.java
@@ -26,7 +26,6 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.testretry.internal.TestName;
-import org.gradle.util.GradleVersion;
 import org.objectweb.asm.ClassReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +63,7 @@ final class TestNgTestFrameworkStrategy implements TestFrameworkStrategy {
                 }
             });
 
-        if (GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version("6.6")) >= 0) {
+        if (TestFrameworkStrategy.gradleVersionIsAtLeast("6.6")) {
             final ObjectFactory objectFactory = ((ProjectInternal) testTask.getProject()).getServices().get(ObjectFactory.class);
             return new TestNGTestFramework(testTask, testTask.getClasspath(), retriedTestFilter, objectFactory);
         } else {


### PR DESCRIPTION
This set of changes fixes #62 by copying `TestNGOptions` to the new `TestFramework` instance used for TestNG test retry.
Although not yet confirmed, I believe this will fix #54 and #55 as well.

This PR also took the opportunity to fix #57.