### PR TITLE
Fix issue where parameters without toString() cannot be retried

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/RetryTestResultProcessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/RetryTestResultProcessor.java
@@ -52,7 +52,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
     public void started(TestDescriptorInternal descriptor, TestStartEvent testStartEvent) {
         testFrameworkStrategy.removeSyntheticFailures(nonExecutedFailedTests, descriptor);
 
-        nonExecutedFailedTests.remove(new TestName(descriptor.getClassName(), descriptor.getName()));
+        nonExecutedFailedTests.remove(testFrameworkStrategy.getTestNameFrom(descriptor));
 
         if (rootTestDescriptorId == null) {
             rootTestDescriptorId = descriptor.getId();
@@ -84,7 +84,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
     public void failure(Object testId, Throwable throwable) {
         TestDescriptorInternal descriptor = activeDescriptorsById.get(testId);
         if (descriptor != null && descriptor.getClassName() != null) {
-            failedTests.add(new TestName(descriptor.getClassName(), descriptor.getName()));
+            failedTests.add(testFrameworkStrategy.getTestNameFrom(descriptor));
         }
         delegate.failure(testId, throwable);
     }

--- a/plugin/src/main/java/org/gradle/testretry/internal/framework/BaseJunitTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/framework/BaseJunitTestFrameworkStrategy.java
@@ -18,6 +18,7 @@ package org.gradle.testretry.internal.framework;
 import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
+import org.gradle.api.tasks.testing.TestDescriptor;
 import org.gradle.testretry.internal.TestName;
 import org.jetbrains.annotations.NotNull;
 import org.objectweb.asm.ClassReader;
@@ -129,5 +130,10 @@ abstract class BaseJunitTestFrameworkStrategy implements TestFrameworkStrategy {
                 }
             })
             .orElse(false);
+    }
+
+    @Override
+    public TestName getTestNameFrom(TestDescriptor descriptor) {
+        return new TestName(descriptor.getClassName(), descriptor.getName());
     }
 }

--- a/plugin/src/main/java/org/gradle/testretry/internal/framework/TestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/framework/TestFrameworkStrategy.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.tasks.testing.junit.JUnitTestFramework;
 import org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework;
 import org.gradle.api.internal.tasks.testing.testng.TestNGTestFramework;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.api.tasks.testing.TestDescriptor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.testretry.internal.TestName;
 import org.gradle.util.GradleVersion;
@@ -50,4 +51,6 @@ public interface TestFrameworkStrategy {
     void removeSyntheticFailures(Set<TestName> nonExecutedFailedTests, TestDescriptorInternal descriptor);
 
     TestFramework createRetrying(JvmTestExecutionSpec spec, Test testTask, Set<TestName> failedTests, Instantiator instantiator, ClassLoaderCache classLoaderCache);
+
+    TestName getTestNameFrom(TestDescriptor descriptor);
 }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGFuncTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.testretry.testframework
 
 import org.gradle.testretry.AbstractPluginFuncTest
+import spock.lang.Issue
 import spock.lang.Unroll
 
 class TestNGFuncTest extends AbstractPluginFuncTest {
@@ -253,6 +254,61 @@ class TestNGFuncTest extends AbstractPluginFuncTest {
     }
 
     @Unroll
+    @Issue("https://github.com/gradle/test-retry-gradle-plugin/issues/66")
+    def "handles parameters with #parameterRepresentation.name() toString() representation (gradle version #gradleVersion)"() {
+        given:
+        buildFile << """
+            test.retry.maxRetries = 1
+        """
+
+        writeTestSource """
+            package acme;
+
+            import org.testng.annotations.*;
+
+            import static org.testng.AssertJUnit.assertEquals;
+
+            public class ParameterTest {
+                public class Foo {
+                    final int value;
+
+                    public Foo(int value) {
+                        this.value = value;
+                    }
+
+                    public String toString() {
+                        return ${parameterRepresentation.representation};
+                    }
+                }
+
+                @DataProvider(name = "parameters")
+                public Object[] createParameters() {
+                    return new Object[]{new Foo(0), new Foo(1)};
+                }
+
+                @Test(dataProvider = "parameters")
+                public void test(Foo foo) {
+                    assertEquals(0, foo.value);
+                }
+            }
+        """
+
+        when:
+        def result = gradleRunner(gradleVersion).buildAndFail()
+
+        then:
+        // we can't rerun just the failed parameter
+        result.output.readLines().findAll { line -> line.matches('.*test\\[0].* PASSED') }.size() == 2
+        result.output.readLines().findAll { line -> line.matches('.*test\\[1].* FAILED') }.size() == 2
+
+        where:
+        [gradleVersion, parameterRepresentation] << GroovyCollections.combinations((Iterable) [
+            GRADLE_VERSIONS_UNDER_TEST,
+            ParameterExceptionString.values()
+        ])
+    }
+
+    @Unroll
     def "uses configured test listeners for test retry (gradle version #gradleVersion)"() {
         given:
         buildFile << """
@@ -281,14 +337,14 @@ class TestNGFuncTest extends AbstractPluginFuncTest {
 
         writeTestSource """
             package acme;
-            
+
             public class LoggingTestListener extends org.testng.TestListenerAdapter {
                 @Override
                 public void onTestStart(org.testng.ITestResult result) {
                     System.out.println("[LoggingTestListener] Test started: " + result.getName());
                 }
-            }     
-"""
+            }
+        """
 
         when:
         def result = gradleRunner(gradleVersion).build()
@@ -314,6 +370,22 @@ class TestNGFuncTest extends AbstractPluginFuncTest {
                 useTestNG()
             }
         """
+    }
+
+    enum ParameterExceptionString {
+        EMPTY('""'),
+        NULL('null'),
+        MISSING('super.toString()')
+
+        String representation;
+
+        ParameterExceptionString(String representation) {
+            this.representation = representation;
+        }
+
+        String getRepresentation() {
+            return representation
+        }
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/gradle/test-retry-gradle-plugin/issues/66.

This resolves the issue by ignoring the parameterized test method name while recording the failed test and only capturing the non-parameterized test method name.  This is fine because we always execute the full set of parameters on retry, so only the non-parameterized test method is important.