### PR TITLE
Emit synthetic passed events for previously failed lifecycle failures

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
@@ -95,7 +95,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
 
     private void emitFakePassedEvent(TestDescriptorInternal parent, TestCompleteEvent parentEvent, String name) {
         Object syntheticTestId = new Object();
-        TestDescriptorInternal syntheticDescriptor = new TestDescriptorImpl(syntheticTestId, parent.getOwnerBuildOperationId(), parent.getClassName(), name);
+        TestDescriptorInternal syntheticDescriptor = new TestDescriptorImpl(syntheticTestId, parent, name);
         long timestamp = parentEvent.getEndTime();
         delegate.started(syntheticDescriptor, new TestStartEvent(timestamp, parent.getId()));
         delegate.completed(syntheticTestId, new TestCompleteEvent(timestamp));

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
@@ -55,9 +55,6 @@ final class RetryTestResultProcessor implements TestResultProcessor {
             activeDescriptorsById.put(descriptor.getId(), descriptor);
             delegate.started(descriptor, testStartEvent);
         } else if (!descriptor.getId().equals(rootTestDescriptorId)) {
-            if (descriptor.getClassName() != null && descriptor.getClassName().equals(descriptor.getName())) {
-                previousRoundFailedTests.remove(descriptor.getClassName(), testFrameworkStrategy::isSyntheticFailure);
-            }
             activeDescriptorsById.put(descriptor.getId(), descriptor);
             delegate.started(descriptor, testStartEvent);
         }
@@ -78,10 +75,34 @@ final class RetryTestResultProcessor implements TestResultProcessor {
                 if (failedInPreviousRound && testCompleteEvent.getResultType() == SKIPPED) {
                     currentRoundFailedTests.add(testName.getClassName(), testName.getName());
                 }
+
+                if (isClassDescriptor(descriptor)) {
+                    previousRoundFailedTests.remove(descriptor.getClassName(), name -> {
+                        if (testFrameworkStrategy.isSyntheticFailure(name)) {
+                            emitFakePassedEvent(descriptor, testCompleteEvent, name);
+                            return true;
+                        } else {
+                            return false;
+                        }
+                    });
+                }
+
             }
         }
 
         delegate.completed(testId, testCompleteEvent);
+    }
+
+    private void emitFakePassedEvent(TestDescriptorInternal parent, TestCompleteEvent parentEvent, String name) {
+        Object syntheticTestId = new Object();
+        TestDescriptorInternal syntheticDescriptor = new TestDescriptorImpl(syntheticTestId, parent.getOwnerBuildOperationId(), parent.getClassName(), name);
+        long timestamp = parentEvent.getEndTime();
+        delegate.started(syntheticDescriptor, new TestStartEvent(timestamp, parent.getId()));
+        delegate.completed(syntheticTestId, new TestCompleteEvent(timestamp));
+    }
+
+    private boolean isClassDescriptor(TestDescriptorInternal descriptor) {
+        return descriptor.getClassName() != null && descriptor.getClassName().equals(descriptor.getName());
     }
 
     @Override

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/TestDescriptorImpl.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/TestDescriptorImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry.internal.executer;
+
+import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
+
+import javax.annotation.Nullable;
+
+final class TestDescriptorImpl implements TestDescriptorInternal {
+
+    private final Object syntheticTestId;
+    private final Object ownerBuildOperationId;
+    private final String className;
+    private final String testName;
+
+    public TestDescriptorImpl(Object testId, Object ownerBuildOperationId, String className, String testName) {
+        this.syntheticTestId = testId;
+        this.ownerBuildOperationId = ownerBuildOperationId;
+        this.className = className;
+        this.testName = testName;
+    }
+
+    @Override
+    public TestDescriptorInternal getParent() {
+        return null;
+    }
+
+    @Override
+    public Object getId() {
+        return syntheticTestId;
+    }
+
+    @Nullable
+    @Override
+    public Object getOwnerBuildOperationId() {
+        return ownerBuildOperationId;
+    }
+
+    @Nullable
+    @Override
+    public String getClassName() {
+        return className;
+    }
+
+    @Override
+    public String getClassDisplayName() {
+        return className;
+    }
+
+    @Override
+    public String getName() {
+        return testName;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return testName;
+    }
+
+    @Override
+    public boolean isComposite() {
+        return false;
+    }
+}

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/TestDescriptorImpl.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/TestDescriptorImpl.java
@@ -22,14 +22,12 @@ import javax.annotation.Nullable;
 final class TestDescriptorImpl implements TestDescriptorInternal {
 
     private final Object syntheticTestId;
-    private final Object ownerBuildOperationId;
-    private final String className;
+    private final TestDescriptorInternal parent;
     private final String testName;
 
-    public TestDescriptorImpl(Object testId, Object ownerBuildOperationId, String className, String testName) {
+    public TestDescriptorImpl(Object testId, TestDescriptorInternal parent, String testName) {
         this.syntheticTestId = testId;
-        this.ownerBuildOperationId = ownerBuildOperationId;
-        this.className = className;
+        this.parent = parent;
         this.testName = testName;
     }
 
@@ -46,18 +44,18 @@ final class TestDescriptorImpl implements TestDescriptorInternal {
     @Nullable
     @Override
     public Object getOwnerBuildOperationId() {
-        return ownerBuildOperationId;
+        return parent.getOwnerBuildOperationId();
     }
 
     @Nullable
     @Override
     public String getClassName() {
-        return className;
+        return parent.getClassName();
     }
 
     @Override
     public String getClassDisplayName() {
-        return className;
+        return parent.getClassDisplayName();
     }
 
     @Override

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4ViaJUnitVintageFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4ViaJUnitVintageFuncTest.groovy
@@ -28,12 +28,12 @@ class JUnit4ViaJUnitVintageFuncTest extends JUnit4FuncTest {
     }
 
     @Override
-    protected String classRuleAfterErrorTestMethodName(String gradleVersion) {
+    protected String afterClassErrorTestMethodName(String gradleVersion) {
         "executionError"
     }
 
     @Override
-    protected String classRuleBeforeErrorTestMethodName(String gradleVersion) {
+    protected String beforeClassErrorTestMethodName(String gradleVersion) {
         "initializationError"
     }
 

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4ViaJUnitVintageFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4ViaJUnitVintageFuncTest.groovy
@@ -29,12 +29,12 @@ class JUnit4ViaJUnitVintageFuncTest extends JUnit4FuncTest {
 
     @Override
     protected String afterClassErrorTestMethodName(String gradleVersion) {
-        "executionError"
+        gradleVersion == "5.0" ? "classMethod" : "executionError"
     }
 
     @Override
     protected String beforeClassErrorTestMethodName(String gradleVersion) {
-        "initializationError"
+        gradleVersion == "5.0" ? "classMethod" : "initializationError"
     }
 
     protected String buildConfiguration() {

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.testretry.testframework
 
+
 import org.gradle.testretry.AbstractFrameworkFuncTest
 import spock.lang.Unroll
 
@@ -30,10 +31,10 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
     }
 
     @Unroll
-    def "handles failure in #lifecycle (gradle version #gradleVersion)"() {
+    def "handles failure in #lifecycle - exhaustive #exhaust (gradle version #gradleVersion)"() {
         given:
         buildFile << """
-            test.retry.maxRetries = 1
+            test.retry.maxRetries = 2
         """
 
         writeTestSource """
@@ -42,7 +43,7 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
             class SuccessfulTests {
                 @org.junit.jupiter.api.${lifecycle}
                 ${lifecycle.contains('All') ? 'static ' : ''}void lifecycle() {
-                    ${flakyAssert()}
+                    ${flakyAssert("id", exhaust ? 3 : 2)}
                 }
 
                 @org.junit.jupiter.api.Test
@@ -51,15 +52,51 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
         """
 
         when:
-        def result = gradleRunner(gradleVersion as String).build()
+        def runner = gradleRunner(gradleVersion as String)
+        def result = exhaust ? runner.buildAndFail() : runner.build()
 
         then:
-        result.output.count('successTest() PASSED') >= 1
+        if (exhaust) {
+            if (lifecycle == "BeforeAll") {
+                assert result.output.count('initializationError FAILED') == 3
+                assert result.output.count('initializationError PASSED') == 0
+                assert result.output.count('successTest() FAILED') == 0
+                assert result.output.count('successTest() PASSED') == 0
+            } else if (lifecycle == "BeforeEach" || lifecycle == "AfterEach") {
+                assert result.output.count('initializationError FAILED') == 0
+                assert result.output.count('initializationError PASSED') == 0
+                assert result.output.count('successTest() FAILED') == 3
+                assert result.output.count('successTest() PASSED') == 0
+            } else if (lifecycle == "AfterAll") {
+                assert result.output.count('executionError FAILED') == 3
+                assert result.output.count('executionError PASSED') == 0
+                assert result.output.count('successTest() FAILED') == 0
+                assert result.output.count('successTest() PASSED') == 3
+            }
+        } else {
+            if (lifecycle == "BeforeAll") {
+                assert result.output.count('initializationError FAILED') == 2
+                assert result.output.count('initializationError PASSED') == 1
+                assert result.output.count('successTest() FAILED') == 0
+                assert result.output.count('successTest() PASSED') == 1
+            } else if (lifecycle == "BeforeEach" || lifecycle == "AfterEach") {
+                assert result.output.count('initializationError FAILED') == 0
+                assert result.output.count('initializationError PASSED') == 0
+                assert result.output.count('successTest() FAILED') == 2
+                assert result.output.count('successTest() PASSED') == 1
+            } else if (lifecycle == "AfterAll") {
+                assert result.output.count('executionError FAILED') == 2
+                assert result.output.count('executionError PASSED') == 1
+                assert result.output.count('successTest() FAILED') == 0
+                assert result.output.count('successTest() PASSED') == 3
+            }
+        }
 
         where:
-        [gradleVersion, lifecycle] << GroovyCollections.combinations((Iterable) [
+        [gradleVersion, lifecycle, exhaust] << GroovyCollections.combinations((Iterable) [
             GRADLE_VERSIONS_UNDER_TEST,
-            ['BeforeAll', 'BeforeEach', 'AfterAll', 'AfterEach']
+            ['BeforeAll', 'BeforeEach', 'AfterAll', 'AfterEach'],
+            [true, false]
         ])
     }
 

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
@@ -30,8 +30,16 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
         return "@org.junit.jupiter.api.Test"
     }
 
+    protected String afterClassErrorTestMethodName(String gradleVersion) {
+        gradleVersion == "5.0" ? "classMethod" : "executionError"
+    }
+
+    protected String beforeClassErrorTestMethodName(String gradleVersion) {
+        gradleVersion == "5.0" ? "classMethod" : "initializationError"
+    }
+
     @Unroll
-    def "handles failure in #lifecycle - exhaustive #exhaust (gradle version #gradleVersion)"() {
+    def "handles failure in #lifecycle - exhaustive #exhaust (gradle version #gradleVersion)"(String gradleVersion, String lifecycle, boolean exhaust) {
         given:
         buildFile << """
             test.retry.maxRetries = 2
@@ -58,8 +66,8 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
         then:
         if (exhaust) {
             if (lifecycle == "BeforeAll") {
-                assert result.output.count('initializationError FAILED') == 3
-                assert result.output.count('initializationError PASSED') == 0
+                assert result.output.count("${beforeClassErrorTestMethodName(gradleVersion)} FAILED") == 3
+                assert result.output.count("${beforeClassErrorTestMethodName(gradleVersion)} PASSED") == 0
                 assert result.output.count('successTest() FAILED') == 0
                 assert result.output.count('successTest() PASSED') == 0
             } else if (lifecycle == "BeforeEach" || lifecycle == "AfterEach") {
@@ -68,15 +76,15 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
                 assert result.output.count('successTest() FAILED') == 3
                 assert result.output.count('successTest() PASSED') == 0
             } else if (lifecycle == "AfterAll") {
-                assert result.output.count('executionError FAILED') == 3
-                assert result.output.count('executionError PASSED') == 0
+                assert result.output.count("${afterClassErrorTestMethodName(gradleVersion)} FAILED") == 3
+                assert result.output.count("${afterClassErrorTestMethodName(gradleVersion)} PASSED") == 0
                 assert result.output.count('successTest() FAILED') == 0
                 assert result.output.count('successTest() PASSED') == 3
             }
         } else {
             if (lifecycle == "BeforeAll") {
-                assert result.output.count('initializationError FAILED') == 2
-                assert result.output.count('initializationError PASSED') == 1
+                assert result.output.count("${beforeClassErrorTestMethodName(gradleVersion)} FAILED") == 2
+                assert result.output.count("${beforeClassErrorTestMethodName(gradleVersion)} PASSED") == 1
                 assert result.output.count('successTest() FAILED') == 0
                 assert result.output.count('successTest() PASSED') == 1
             } else if (lifecycle == "BeforeEach" || lifecycle == "AfterEach") {
@@ -85,8 +93,8 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
                 assert result.output.count('successTest() FAILED') == 2
                 assert result.output.count('successTest() PASSED') == 1
             } else if (lifecycle == "AfterAll") {
-                assert result.output.count('executionError FAILED') == 2
-                assert result.output.count('executionError PASSED') == 1
+                assert result.output.count("${afterClassErrorTestMethodName(gradleVersion)} FAILED") == 2
+                assert result.output.count("${afterClassErrorTestMethodName(gradleVersion)} PASSED") == 1
                 assert result.output.count('successTest() FAILED') == 0
                 assert result.output.count('successTest() PASSED') == 3
             }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock2FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock2FuncTest.groovy
@@ -30,6 +30,16 @@ class Spock2FuncTest extends SpockBaseJunit5FuncTest {
     }
 
     @Override
+    protected String beforeClassErrorTestMethodName(String gradleVersion) {
+        gradleVersion == "5.0" ? "classMethod" : "initializationError"
+    }
+
+    @Override
+    protected String afterClassErrorTestMethodName(String gradleVersion) {
+        gradleVersion == "5.0" ? "classMethod" : "executionError"
+    }
+
+    @Override
     protected String buildConfiguration() {
         return """
             dependencies {

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseJunit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseJunit5FuncTest.groovy
@@ -15,18 +15,25 @@
  */
 package org.gradle.testretry.testframework
 
-class Spock2FuncTest extends SpockBaseJunit5FuncTest {
+class SpockBaseJunit5FuncTest extends SpockFuncTest {
 
-    @Override
-    boolean canTargetInheritedMethods() {
-        // https://github.com/spockframework/spock/issues/1235
+    boolean isRerunsParameterizedMethods() {
         false
     }
 
     @Override
-    boolean nonParameterizedMethodsCanHaveCustomIterationNames() {
-        // // https://github.com/spockframework/spock/issues/1236
-        false
+    protected String staticInitErrorTestMethodName(String gradleVersion) {
+        gradleVersion == "5.0" ? "classMethod" : "initializationError"
+    }
+
+    @Override
+    protected String beforeClassErrorTestMethodName(String gradleVersion) {
+        "initializationError"
+    }
+
+    @Override
+    protected String afterClassErrorTestMethodName(String gradleVersion) {
+        "executionError"
     }
 
     @Override

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseJunit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseJunit5FuncTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.testretry.testframework
 
-class SpockBaseJunit5FuncTest extends SpockFuncTest {
+abstract class SpockBaseJunit5FuncTest extends SpockFuncTest {
 
     boolean isRerunsParameterizedMethods() {
         false

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockViaJUnitVintageFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockViaJUnitVintageFuncTest.groovy
@@ -18,6 +18,16 @@ package org.gradle.testretry.testframework
 class SpockViaJUnitVintageFuncTest extends SpockBaseJunit5FuncTest {
 
     @Override
+    protected String beforeClassErrorTestMethodName(String gradleVersion) {
+        gradleVersion == "5.0" ? "classMethod" : "initializationError"
+    }
+
+    @Override
+    protected String afterClassErrorTestMethodName(String gradleVersion) {
+        gradleVersion == "5.0" ? "classMethod" : "executionError"
+    }
+
+    @Override
     protected String buildConfiguration() {
         return """
             dependencies {

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockViaJUnitVintageFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockViaJUnitVintageFuncTest.groovy
@@ -15,16 +15,7 @@
  */
 package org.gradle.testretry.testframework
 
-class SpockViaJUnitVintageFuncTest extends SpockFuncTest {
-
-    boolean isRerunsParameterizedMethods() {
-        false
-    }
-
-    @Override
-    protected String initializationErrorSyntheticTestMethodName(String gradleVersion) {
-        gradleVersion == "5.0" ? "classMethod" : "initializationError"
-    }
+class SpockViaJUnitVintageFuncTest extends SpockBaseJunit5FuncTest {
 
     @Override
     protected String buildConfiguration() {


### PR DESCRIPTION
Fixes #65

After spending a lot of time trying to make it also work for TestNg and failing, I simplified and just made it work for JUnit.