### PR TITLE
Allow specifying which classes may be retried

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -57,7 +57,9 @@ The `retry` extension is of the following type:
 ----
 package org.gradle.testretry;
 
+import org.gradle.api.Action;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.testing.Test;
 
 /**
@@ -68,6 +70,11 @@ import org.gradle.api.tasks.testing.Test;
 public interface TestRetryTaskExtension {
 
     /**
+     * The name of the extension added to each test task.
+     */
+    String NAME = "retry";
+
+    /**
      * Whether tests that initially fail and then pass on retry should fail the task.
      * <p>
      * This setting defaults to {@code false},
@@ -75,7 +82,7 @@ public interface TestRetryTaskExtension {
      * <p>
      * This setting has no effect if {@link Test#getIgnoreFailures()} is set to true.
      *
-     * @return whether tests that initially fail and then pass on retry should fail the task
+     * @return whether tests that initially fails and then pass on retry should fail the task
      */
     Property<Boolean> getFailOnPassedAfterRetry();
 
@@ -103,6 +110,77 @@ public interface TestRetryTaskExtension {
      * @return the maximum number of test failures that are allowed before retrying is disabled
      */
     Property<Integer> getMaxFailures();
+
+    /**
+     * The filter for specifying which tests may be retried.
+     */
+    Filter getFilter();
+
+    /**
+     * The filter for specifying which tests may be retried.
+     */
+    void filter(Action<? super Filter> action);
+
+    /**
+     * A filter for specifying which tests may be retried.
+     *
+     * By default, all tests are eligible for retrying.
+     */
+    interface Filter {
+
+        /**
+         * The patterns used to include tests based on their class name.
+         *
+         * The pattern string matches against qualified class names.
+         * It may contain '*' characters, which match zero or more of any character.
+         *
+         * A class name only has to match one pattern to be included.
+         *
+         * If no patterns are specified, all classes (that also meet other configured filters) will be included.
+         */
+        SetProperty<String> getIncludeClasses();
+
+        /**
+         * The patterns used to include tests based on their class level annotations.
+         *
+         * The pattern string matches against the qualified class names of a test class's annotations.
+         * It may contain '*' characters, which match zero or more of any character.
+         *
+         * A class need only have one annotation matching any of the patterns to be included.
+         *
+         * Annotations present on super classes that are {@code @Inherited} are considered when inspecting subclasses.
+         *
+         * If no patterns are specified, all classes (that also meet other configured filters) will be included.
+         */
+        SetProperty<String> getIncludeAnnotationClasses();
+
+        /**
+         * The patterns used to exclude tests based on their class name.
+         *
+         * The pattern string matches against qualified class names.
+         * It may contain '*' characters, which match zero or more of any character.
+         *
+         * A class name only has to match one pattern to be excluded.
+         *
+         * If no patterns are specified, all classes (that also meet other configured filters) will be included.
+         */
+        SetProperty<String> getExcludeClasses();
+
+        /**
+         * The patterns used to exclude tests based on their class level annotations.
+         *
+         * The pattern string matches against the qualified class names of a test class's annotations.
+         * It may contain '*' characters, which match zero or more of any character.
+         *
+         * A class need only have one annotation matching any of the patterns to be excluded.
+         *
+         * Annotations present on super classes that are {@code @Inherited} are considered when inspecting subclasses.
+         *
+         * If no patterns are specified, all classes (that also meet other configured filters) will be included.
+         */
+        SetProperty<String> getExcludeAnnotationClasses();
+
+    }
 
 }
 ----
@@ -142,6 +220,34 @@ The plugin supports retrying Spock `@Stepwise` tests and TestNG `@Test(dependsOn
 
 * Upstream tests (those that the failed test depends on) are run because a flaky test may depend on state from the prior execution of an upstream test.
 * Downstream tests are run because a flaky test causes any downstream tests to be skipped in the initial test run.
+
+== Filtering
+
+By default, all tests are eligible for retrying.
+The `filter` component of the test retry extension can be used to control which tests should be retried and which should not.
+
+The decision to retry a test or not is based on the tests reported class name, regardless of the name of the test case or method.
+The annotations present or not on this class can also be used as the criteria.
+
+.build.gradle:
+[source,groovy]
+----
+test {
+    retry {
+        maxRetries = 3
+        filter {
+            // filter by qualified class name (* matches zero or more of any character)
+            includeClasses.add("*IntegrationTest")
+            excludeClasses.add("*DatabaseTest")
+
+            // filter by class level annotations
+            // Note: @Inherited annotations are respected
+            includeAnnotationClasses.add("*Retryable")
+            excludeAnnotationClasses.add("*NonRetryable")
+        }
+    }
+}
+----
 
 == Reporting
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     testImplementation(localGroovy())
     testImplementation("org.spockframework:spock-core:1.3-groovy-2.5")
     testImplementation("net.sourceforge.nekohtml:nekohtml:1.9.22")
+    testImplementation("org.ow2.asm:asm:8.0.1")
 
     codenarc("org.codenarc:CodeNarc:1.0")
 }

--- a/plugin/src/main/java/org/gradle/testretry/TestRetryTaskExtension.java
+++ b/plugin/src/main/java/org/gradle/testretry/TestRetryTaskExtension.java
@@ -70,50 +70,71 @@ public interface TestRetryTaskExtension {
     Property<Integer> getMaxFailures();
 
     /**
-     * Filtering for which tests may be retried.
+     * The filter for specifying which tests may be retried.
      */
-    Filters getFilters();
+    Filter getFilter();
 
     /**
-     * Filtering for which tests may be retried.
+     * The filter for specifying which tests may be retried.
      */
-    void filters(Action<? super Filters> action);
+    void filter(Action<? super Filter> action);
 
-    interface Filters {
+    /**
+     * A filter for specifying which tests may be retried.
+     *
+     * By default, all tests are eligible for retrying.
+     */
+    interface Filter {
 
         /**
-         * A set of full class name patterns of classes to include.
+         * The patterns used to include tests based on their class name.
          *
-         * If no patterns are specified, all classes (that meet other criteria) will be included.
+         * The pattern string matches against qualified class names.
+         * It may contain '*' characters, which match zero or more of any character.
          *
-         * '*' can be used to match zero or more characters in a class name.
+         * A class name only has to match one pattern to be included.
+         *
+         * If no patterns are specified, all classes (that also meet other configured filters) will be included.
          */
         SetProperty<String> getIncludeClasses();
 
         /**
-         * A set of full annotation class name patterns to use to include a class for retry if annotated with an annotation matching the pattern.
+         * The patterns used to include tests based on their class level annotations.
          *
-         * If no patterns are specified, all classes (that meet other criteria) will be included.
+         * The pattern string matches against the qualified class names of a test class's annotations.
+         * It may contain '*' characters, which match zero or more of any character.
          *
-         * '*' can be used to match zero or more characters in a class name.
+         * A class need only have one annotation matching any of the patterns to be included.
+         *
+         * Annotations present on super classes that are {@code @Inherited} are considered when inspecting subclasses.
+         *
+         * If no patterns are specified, all classes (that also meet other configured filters) will be included.
          */
         SetProperty<String> getIncludeAnnotationClasses();
 
         /**
-         * A set of full class name patterns of classes to exclude.
+         * The patterns used to exclude tests based on their class name.
          *
-         * If no patterns are specified, all classes (that meet other criteria) will be included.
+         * The pattern string matches against qualified class names.
+         * It may contain '*' characters, which match zero or more of any character.
          *
-         * '*' can be used to match zero or more characters in a class name.
+         * A class name only has to match one pattern to be excluded.
+         *
+         * If no patterns are specified, all classes (that also meet other configured filters) will be included.
          */
         SetProperty<String> getExcludeClasses();
 
         /**
-         * A set of full annotation class name patterns to use to exclude a class for retry if annotated with an annotation matching the pattern.
+         * The patterns used to exclude tests based on their class level annotations.
          *
-         * If no patterns are specified, all classes (that meet other criteria) will be included.
+         * The pattern string matches against the qualified class names of a test class's annotations.
+         * It may contain '*' characters, which match zero or more of any character.
          *
-         * '*' can be used to match zero or more characters in a class name.
+         * A class need only have one annotation matching any of the patterns to be excluded.
+         *
+         * Annotations present on super classes that are {@code @Inherited} are considered when inspecting subclasses.
+         *
+         * If no patterns are specified, all classes (that also meet other configured filters) will be included.
          */
         SetProperty<String> getExcludeAnnotationClasses();
 

--- a/plugin/src/main/java/org/gradle/testretry/TestRetryTaskExtension.java
+++ b/plugin/src/main/java/org/gradle/testretry/TestRetryTaskExtension.java
@@ -15,7 +15,9 @@
  */
 package org.gradle.testretry;
 
+import org.gradle.api.Action;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.testing.Test;
 
 /**
@@ -66,5 +68,55 @@ public interface TestRetryTaskExtension {
      * @return the maximum number of test failures that are allowed before retrying is disabled
      */
     Property<Integer> getMaxFailures();
+
+    /**
+     * Filtering for which tests may be retried.
+     */
+    Filters getFilters();
+
+    /**
+     * Filtering for which tests may be retried.
+     */
+    void filters(Action<? super Filters> action);
+
+    interface Filters {
+
+        /**
+         * A set of full class name patterns of classes to include.
+         *
+         * If no patterns are specified, all classes (that meet other criteria) will be included.
+         *
+         * '*' can be used to match zero or more characters in a class name.
+         */
+        SetProperty<String> getIncludeClasses();
+
+        /**
+         * A set of full annotation class name patterns to use to include a class for retry if annotated with an annotation matching the pattern.
+         *
+         * If no patterns are specified, all classes (that meet other criteria) will be included.
+         *
+         * '*' can be used to match zero or more characters in a class name.
+         */
+        SetProperty<String> getIncludeAnnotationClasses();
+
+        /**
+         * A set of full class name patterns of classes to exclude.
+         *
+         * If no patterns are specified, all classes (that meet other criteria) will be included.
+         *
+         * '*' can be used to match zero or more characters in a class name.
+         */
+        SetProperty<String> getExcludeClasses();
+
+        /**
+         * A set of full annotation class name patterns to use to exclude a class for retry if annotated with an annotation matching the pattern.
+         *
+         * If no patterns are specified, all classes (that meet other criteria) will be included.
+         *
+         * '*' can be used to match zero or more characters in a class name.
+         */
+        SetProperty<String> getExcludeAnnotationClasses();
+
+    }
 
 }

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/DefaultTestRetryTaskExtension.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/DefaultTestRetryTaskExtension.java
@@ -28,14 +28,14 @@ public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
     private final Property<Boolean> failOnPassedAfterRetry;
     private final Property<Integer> maxRetries;
     private final Property<Integer> maxFailures;
-    private final Filters filters;
+    private final Filter filter;
 
     @Inject
     public DefaultTestRetryTaskExtension(ObjectFactory objects) {
         this.failOnPassedAfterRetry = objects.property(Boolean.class);
         this.maxRetries = objects.property(Integer.class);
         this.maxFailures = objects.property(Integer.class);
-        this.filters = new FiltersImpl(objects);
+        this.filter = new FilterImpl(objects);
     }
 
     public Property<Boolean> getFailOnPassedAfterRetry() {
@@ -51,23 +51,23 @@ public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
     }
 
     @Override
-    public void filters(Action<? super Filters> action) {
-        action.execute(filters);
+    public void filter(Action<? super Filter> action) {
+        action.execute(filter);
     }
 
     @Override
-    public Filters getFilters() {
-        return filters;
+    public Filter getFilter() {
+        return filter;
     }
 
-    private static final class FiltersImpl implements Filters {
+    private static final class FilterImpl implements Filter {
 
         private final SetProperty<String> includeClasses;
         private final SetProperty<String> includeAnnotationClasses;
         private final SetProperty<String> excludeClasses;
         private final SetProperty<String> excludeAnnotationClasses;
 
-        public FiltersImpl(ObjectFactory objects) {
+        public FilterImpl(ObjectFactory objects) {
             this.includeClasses = objects.setProperty(String.class);
             this.includeAnnotationClasses = objects.setProperty(String.class);
             this.excludeClasses = objects.setProperty(String.class);

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/DefaultTestRetryTaskExtension.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/DefaultTestRetryTaskExtension.java
@@ -15,8 +15,10 @@
  */
 package org.gradle.testretry.internal.config;
 
+import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.testretry.TestRetryTaskExtension;
 
 import javax.inject.Inject;
@@ -26,12 +28,14 @@ public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
     private final Property<Boolean> failOnPassedAfterRetry;
     private final Property<Integer> maxRetries;
     private final Property<Integer> maxFailures;
+    private final Filters filters;
 
     @Inject
     public DefaultTestRetryTaskExtension(ObjectFactory objects) {
         this.failOnPassedAfterRetry = objects.property(Boolean.class);
         this.maxRetries = objects.property(Integer.class);
         this.maxFailures = objects.property(Integer.class);
+        this.filters = new FiltersImpl(objects);
     }
 
     public Property<Boolean> getFailOnPassedAfterRetry() {
@@ -44,6 +48,51 @@ public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
 
     public Property<Integer> getMaxFailures() {
         return maxFailures;
+    }
+
+    @Override
+    public void filters(Action<? super Filters> action) {
+        action.execute(filters);
+    }
+
+    @Override
+    public Filters getFilters() {
+        return filters;
+    }
+
+    private static final class FiltersImpl implements Filters {
+
+        private final SetProperty<String> includeClasses;
+        private final SetProperty<String> includeAnnotationClasses;
+        private final SetProperty<String> excludeClasses;
+        private final SetProperty<String> excludeAnnotationClasses;
+
+        public FiltersImpl(ObjectFactory objects) {
+            this.includeClasses = objects.setProperty(String.class);
+            this.includeAnnotationClasses = objects.setProperty(String.class);
+            this.excludeClasses = objects.setProperty(String.class);
+            this.excludeAnnotationClasses = objects.setProperty(String.class);
+        }
+
+        @Override
+        public SetProperty<String> getIncludeClasses() {
+            return includeClasses;
+        }
+
+        @Override
+        public SetProperty<String> getIncludeAnnotationClasses() {
+            return includeAnnotationClasses;
+        }
+
+        @Override
+        public SetProperty<String> getExcludeClasses() {
+            return excludeClasses;
+        }
+
+        @Override
+        public SetProperty<String> getExcludeAnnotationClasses() {
+            return excludeAnnotationClasses;
+        }
     }
 
 }

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
@@ -59,10 +59,10 @@ public final class TestRetryTaskExtensionAdapter {
         extension.getMaxRetries().convention(DEFAULT_MAX_RETRIES);
         extension.getMaxFailures().convention(DEFAULT_MAX_FAILURES);
         extension.getFailOnPassedAfterRetry().convention(DEFAULT_FAIL_ON_PASSED_AFTER_RETRY);
-        extension.getFilters().getIncludeClasses().convention(Collections.emptySet());
-        extension.getFilters().getIncludeAnnotationClasses().convention(Collections.emptySet());
-        extension.getFilters().getExcludeClasses().convention(Collections.emptySet());
-        extension.getFilters().getExcludeAnnotationClasses().convention(Collections.emptySet());
+        extension.getFilter().getIncludeClasses().convention(Collections.emptySet());
+        extension.getFilter().getIncludeAnnotationClasses().convention(Collections.emptySet());
+        extension.getFilter().getExcludeClasses().convention(Collections.emptySet());
+        extension.getFilter().getExcludeAnnotationClasses().convention(Collections.emptySet());
     }
 
     Callable<Provider<Boolean>> getFailOnPassedAfterRetryInput() {
@@ -92,19 +92,19 @@ public final class TestRetryTaskExtensionAdapter {
     }
 
     public Set<String> getIncludeClasses() {
-        return read(extension.getFilters().getIncludeClasses(), Collections.emptySet());
+        return read(extension.getFilter().getIncludeClasses(), Collections.emptySet());
     }
 
     public Set<String> getIncludeAnnotationClasses() {
-        return read(extension.getFilters().getIncludeAnnotationClasses(), Collections.emptySet());
+        return read(extension.getFilter().getIncludeAnnotationClasses(), Collections.emptySet());
     }
 
     public Set<String> getExcludeClasses() {
-        return read(extension.getFilters().getExcludeClasses(), Collections.emptySet());
+        return read(extension.getFilter().getExcludeClasses(), Collections.emptySet());
     }
 
     public Set<String> getExcludeAnnotationClasses() {
-        return read(extension.getFilters().getExcludeAnnotationClasses(), Collections.emptySet());
+        return read(extension.getFilter().getExcludeAnnotationClasses(), Collections.emptySet());
     }
 
     public boolean getSimulateNotRetryableTest() {

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
@@ -18,9 +18,11 @@ package org.gradle.testretry.internal.config;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.testretry.TestRetryTaskExtension;
-import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 public final class TestRetryTaskExtensionAdapter {
@@ -57,6 +59,10 @@ public final class TestRetryTaskExtensionAdapter {
         extension.getMaxRetries().convention(DEFAULT_MAX_RETRIES);
         extension.getMaxFailures().convention(DEFAULT_MAX_FAILURES);
         extension.getFailOnPassedAfterRetry().convention(DEFAULT_FAIL_ON_PASSED_AFTER_RETRY);
+        extension.getFilters().getIncludeClasses().convention(Collections.emptySet());
+        extension.getFilters().getIncludeAnnotationClasses().convention(Collections.emptySet());
+        extension.getFilters().getExcludeClasses().convention(Collections.emptySet());
+        extension.getFilters().getExcludeAnnotationClasses().convention(Collections.emptySet());
     }
 
     Callable<Provider<Boolean>> getFailOnPassedAfterRetryInput() {
@@ -85,12 +91,32 @@ public final class TestRetryTaskExtensionAdapter {
         return read(extension.getMaxFailures(), DEFAULT_MAX_FAILURES);
     }
 
+    public Set<String> getIncludeClasses() {
+        return read(extension.getFilters().getIncludeClasses(), Collections.emptySet());
+    }
+
+    public Set<String> getIncludeAnnotationClasses() {
+        return read(extension.getFilters().getIncludeAnnotationClasses(), Collections.emptySet());
+    }
+
+    public Set<String> getExcludeClasses() {
+        return read(extension.getFilters().getExcludeClasses(), Collections.emptySet());
+    }
+
+    public Set<String> getExcludeAnnotationClasses() {
+        return read(extension.getFilters().getExcludeAnnotationClasses(), Collections.emptySet());
+    }
+
     public boolean getSimulateNotRetryableTest() {
         return simulateNotRetryableTest;
     }
 
-    @NotNull
     private <T> T read(Property<T> property, T defaultValue) {
         return useConventions ? property.get() : property.getOrElse(defaultValue);
     }
+
+    private <T> Set<T> read(SetProperty<T> property, Set<T> defaultValue) {
+        return useConventions ? property.get() : property.getOrElse(defaultValue);
+    }
+
 }

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -42,7 +42,7 @@ public final class TestTaskConfigurer {
 
         TestRetryTaskExtension extension = objectFactory.newInstance(DefaultTestRetryTaskExtension.class);
 
-        TestRetryTaskExtensionAdapter adapter = new TestRetryTaskExtensionAdapter(providerFactory, extension, supportsPropertyConventions(gradleVersion));
+        TestRetryTaskExtensionAdapter adapter = new TestRetryTaskExtensionAdapter(providerFactory, extension, gradleVersion);
 
         test.getInputs().property("retry.failOnPassedAfterRetry", adapter.getFailOnPassedAfterRetryInput());
 

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -40,12 +40,7 @@ public final class TestTaskConfigurer {
     public static void configureTestTask(Test test, ObjectFactory objectFactory, ProviderFactory providerFactory) {
         VersionNumber gradleVersion = VersionNumber.parse(test.getProject().getGradle().getGradleVersion());
 
-        TestRetryTaskExtension extension;
-        if (supportsGeneratedAbstractTypeImplementations(gradleVersion)) {
-            extension = objectFactory.newInstance(TestRetryTaskExtension.class);
-        } else {
-            extension = objectFactory.newInstance(DefaultTestRetryTaskExtension.class);
-        }
+        TestRetryTaskExtension extension = objectFactory.newInstance(DefaultTestRetryTaskExtension.class);
 
         TestRetryTaskExtensionAdapter adapter = new TestRetryTaskExtensionAdapter(providerFactory, extension, supportsPropertyConventions(gradleVersion));
 
@@ -68,10 +63,6 @@ public final class TestTaskConfigurer {
 
     private static void setTestExecuter(Test task, RetryTestExecuter retryTestExecuter) {
         invoke(declaredMethod(Test.class, "setTestExecuter", TestExecuter.class), task, retryTestExecuter);
-    }
-
-    private static boolean supportsGeneratedAbstractTypeImplementations(VersionNumber gradleVersion) {
-        return gradleVersion.getMajor() == 5 ? gradleVersion.getMinor() >= 3 : gradleVersion.getMajor() > 5;
     }
 
     private static boolean supportsPropertyConventions(VersionNumber gradleVersion) {

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/TestFrameworkTemplate.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/TestFrameworkTemplate.java
@@ -18,6 +18,7 @@ package org.gradle.testretry.internal.executer;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.testretry.internal.testsreader.TestsReader;
 
 public class TestFrameworkTemplate {
 

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
@@ -17,7 +17,7 @@ package org.gradle.testretry.internal.executer.framework;
 
 import org.gradle.testretry.internal.executer.TestFilterBuilder;
 import org.gradle.testretry.internal.executer.TestNames;
-import org.gradle.testretry.internal.executer.TestsReader;
+import org.gradle.testretry.internal.testsreader.TestsReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/SpockParameterClassVisitor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/SpockParameterClassVisitor.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.testretry.internal.executer.framework;
 
-import org.gradle.testretry.internal.executer.TestsReader;
+import org.gradle.testretry.internal.testsreader.TestsReader;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.MethodVisitor;
 

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/SpockStepwiseClassVisitor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/SpockStepwiseClassVisitor.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.testretry.internal.executer.framework;
 
-import org.gradle.testretry.internal.executer.TestsReader;
+import org.gradle.testretry.internal.testsreader.TestsReader;
 import org.objectweb.asm.AnnotationVisitor;
 
 final class SpockStepwiseClassVisitor extends TestsReader.Visitor<Boolean> {

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/TestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/TestFrameworkStrategy.java
@@ -21,7 +21,7 @@ import org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFram
 import org.gradle.api.internal.tasks.testing.testng.TestNGTestFramework;
 import org.gradle.testretry.internal.executer.TestFrameworkTemplate;
 import org.gradle.testretry.internal.executer.TestNames;
-import org.gradle.testretry.internal.executer.TestsReader;
+import org.gradle.testretry.internal.testsreader.TestsReader;
 import org.gradle.util.GradleVersion;
 
 /**

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/TestNgClassVisitor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/TestNgClassVisitor.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.testretry.internal.executer.framework;
 
-import org.gradle.testretry.internal.executer.TestsReader;
+import org.gradle.testretry.internal.testsreader.TestsReader;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.MethodVisitor;
 

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/TestNgTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/TestNgTestFrameworkStrategy.java
@@ -27,7 +27,7 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.testretry.internal.executer.TestFilterBuilder;
 import org.gradle.testretry.internal.executer.TestFrameworkTemplate;
 import org.gradle.testretry.internal.executer.TestNames;
-import org.gradle.testretry.internal.executer.TestsReader;
+import org.gradle.testretry.internal.testsreader.TestsReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/plugin/src/main/java/org/gradle/testretry/internal/filter/AnnotationInspector.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/filter/AnnotationInspector.java
@@ -13,24 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.testretry.internal.executer;
+package org.gradle.testretry.internal.filter;
 
-final class RoundResult {
+import java.util.Set;
 
-    final TestNames failedTests;
-    final TestNames nonRetriedTests;
-    final boolean lastRound;
-    final boolean hasRetryFilteredFailures;
+public interface AnnotationInspector {
 
-    RoundResult(
-        TestNames failedTests,
-        TestNames nonRetriedTests,
-        boolean lastRound,
-        boolean hasRetryFilteredFailures
-    ) {
-        this.failedTests = failedTests;
-        this.nonRetriedTests = nonRetriedTests;
-        this.lastRound = lastRound;
-        this.hasRetryFilteredFailures = hasRetryFilteredFailures;
-    }
+    Set<String> getClassAnnotations(String className);
+
 }

--- a/plugin/src/main/java/org/gradle/testretry/internal/filter/AnnotationInspectorImpl.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/filter/AnnotationInspectorImpl.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry.internal.filter;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.testretry.internal.testsreader.TestsReader;
+import org.objectweb.asm.AnnotationVisitor;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class AnnotationInspectorImpl implements AnnotationInspector {
+
+    private static final Logger LOGGER = Logging.getLogger(AnnotationInspectorImpl.class);
+
+    private final Map<String, Set<String>> cache = new HashMap<>();
+    private final Map<String, Boolean> inheritedCache = new HashMap<>();
+
+    private final TestsReader testsReader;
+
+    public AnnotationInspectorImpl(TestsReader testsReader) {
+        this.testsReader = testsReader;
+    }
+
+    @Override
+    public Set<String> getClassAnnotations(String className) {
+        return cache.computeIfAbsent(className, ignored ->
+            testsReader.readClass(className, ClassAnnotationVisitor::new)
+                .orElseGet(() -> {
+                    LOGGER.warn("Unable to find annotations of " + className);
+                    return Collections.emptySet();
+                })
+        );
+    }
+
+    private boolean isInherited(String annotationClassName) {
+        return inheritedCache.computeIfAbsent(annotationClassName, ignored ->
+            testsReader.readClass(annotationClassName, AnnotationAnnotationVisitor::new)
+                .orElseGet(() -> {
+                    LOGGER.warn("Cannot determine whether @" + annotationClassName + " is inherited");
+                    return false;
+                })
+        );
+    }
+
+    final class ClassAnnotationVisitor extends TestsReader.Visitor<Set<String>> {
+
+        private final Set<String> found = new HashSet<>();
+
+        @Override
+        public Set<String> getResult() {
+            return found.isEmpty() ? Collections.emptySet() : found;
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            if (!superName.equals("Ljava/lang/Object;")) {
+                getClassAnnotations(classDescriptorToClassName(superName))
+                    .stream()
+                    .filter(AnnotationInspectorImpl.this::isInherited)
+                    .forEach(found::add);
+            }
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+            found.add(classDescriptorToClassName(descriptor));
+            return null;
+        }
+
+    }
+
+    static final class AnnotationAnnotationVisitor extends TestsReader.Visitor<Boolean> {
+
+        private boolean inherited;
+
+        @Override
+        public Boolean getResult() {
+            return inherited;
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+            if (descriptor.equals("Ljava/lang.annotation/Inherited;")) {
+                inherited = true;
+            }
+            return null;
+        }
+    }
+
+    private static String classDescriptorToClassName(String descriptor) {
+        return descriptor.substring(1, descriptor.length() - 1).replace('/', '.');
+    }
+}

--- a/plugin/src/main/java/org/gradle/testretry/internal/filter/GlobPattern.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/filter/GlobPattern.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry.internal.filter;
+
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+final class GlobPattern {
+
+    public static final Pattern STAR_CHAR_PATTERN = Pattern.compile("\\*");
+    public static final String MATCH_ANY = ".*?";
+
+    private final String string;
+    private final Pattern pattern;
+
+    private GlobPattern(String string, Pattern pattern) {
+        this.string = string;
+        this.pattern = pattern;
+    }
+
+    static GlobPattern from(String string) {
+        String patternString = STAR_CHAR_PATTERN.splitAsStream(string)
+            .map(Pattern::quote)
+            .collect(Collectors.joining(MATCH_ANY));
+
+        if (string.endsWith("*")) {
+            patternString = patternString + MATCH_ANY;
+        }
+
+        Pattern pattern = Pattern.compile(patternString);
+
+        return new GlobPattern(patternString, pattern);
+    }
+
+    boolean matches(String test) {
+        return pattern.matcher(test).matches();
+    }
+
+    @Override
+    public String toString() {
+        return string;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GlobPattern that = (GlobPattern) o;
+
+        return string.equals(that.string);
+    }
+
+    @Override
+    public int hashCode() {
+        return string.hashCode();
+    }
+}

--- a/plugin/src/main/java/org/gradle/testretry/internal/filter/RetryFilter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/filter/RetryFilter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry.internal.filter;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class RetryFilter {
+
+    private final AnnotationInspector annotationInspector;
+
+    private final Set<Pattern> includeClasses;
+    private final Set<Pattern> includeAnnotationClasses;
+    private final Set<Pattern> excludeClasses;
+    private final Set<Pattern> excludeAnnotationClasses;
+
+    public RetryFilter(
+        AnnotationInspector annotationInspector,
+        Set<String> includeClasses,
+        Set<String> includeAnnotationClasses,
+        Set<String> excludeClasses,
+        Set<String> excludeAnnotationClasses
+    ) {
+        this.annotationInspector = annotationInspector;
+        this.includeClasses = toPatterns(includeClasses);
+        this.includeAnnotationClasses = toPatterns(includeAnnotationClasses);
+        this.excludeClasses = toPatterns(excludeClasses);
+        this.excludeAnnotationClasses = toPatterns(excludeAnnotationClasses);
+    }
+
+    public boolean canRetry(String className) {
+        if (!includeClasses.isEmpty()) {
+            boolean matchesNoIncludeClasses = includeClasses.stream()
+                .noneMatch(pattern -> pattern.matcher(className).matches());
+
+            if (matchesNoIncludeClasses) {
+                return false;
+            }
+        }
+
+        if (excludeClasses.stream().anyMatch(pattern -> pattern.matcher(className).matches())) {
+            return false;
+        }
+
+        Set<String> annotations = null;
+        if (!includeAnnotationClasses.isEmpty()) {
+            annotations = annotationInspector.getClassAnnotations(className);
+            boolean hasNoIncludeAnnotation = annotations.stream()
+                .noneMatch(annotation ->
+                    includeAnnotationClasses.stream()
+                        .anyMatch(pattern -> pattern.matcher(annotation).matches())
+                );
+
+            if (!hasNoIncludeAnnotation) {
+                return false;
+            }
+        }
+
+        if (!excludeAnnotationClasses.isEmpty()) {
+            annotations = annotations == null ? annotationInspector.getClassAnnotations(className) : annotations;
+            boolean hasAnyExcludeAnnotation = annotations.stream()
+                .anyMatch(annotation ->
+                    includeAnnotationClasses.stream()
+                        .anyMatch(pattern -> pattern.matcher(annotation).matches())
+                );
+
+            return !hasAnyExcludeAnnotation;
+        }
+
+        return true;
+    }
+
+    private static Set<Pattern> toPatterns(Set<String> strings) {
+        return strings.stream()
+            .map(string ->
+                Arrays.stream(string.split("\\*"))
+                    .map(Pattern::quote)
+                    .collect(Collectors.joining(".*?"))
+                    + (string.endsWith("*") ? ".*?" : "")
+            )
+            .map(Pattern::compile)
+            .collect(Collectors.toSet());
+    }
+}

--- a/plugin/src/main/java/org/gradle/testretry/internal/testsreader/TestsReader.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/testsreader/TestsReader.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.testretry.internal.executer;
+package org.gradle.testretry.internal.testsreader;
 
 import org.jetbrains.annotations.NotNull;
 import org.objectweb.asm.ClassReader;

--- a/plugin/src/test/groovy/org/gradle/testretry/AbstractGeneralPluginFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/AbstractGeneralPluginFuncTest.groovy
@@ -17,10 +17,6 @@ package org.gradle.testretry
 
 abstract class AbstractGeneralPluginFuncTest extends AbstractPluginFuncTest {
 
-    String getTestAnnotation() {
-        return '@org.junit.Test'
-    }
-
     String getLanguagePlugin() {
         return 'java'
     }
@@ -30,7 +26,7 @@ abstract class AbstractGeneralPluginFuncTest extends AbstractPluginFuncTest {
             package acme;
 
             public class SuccessfulTests {
-                ${testAnnotation}
+                @org.junit.Test
                 public void successTest() {}
             }
         """
@@ -56,7 +52,7 @@ abstract class AbstractGeneralPluginFuncTest extends AbstractPluginFuncTest {
             package acme;
 
             public class FlakyTests {
-                ${testAnnotation}
+                @org.junit.Test
                 public void flaky() {
                     ${flakyAssert()}
                 }

--- a/plugin/src/test/groovy/org/gradle/testretry/FilterFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/FilterFuncTest.groovy
@@ -15,55 +15,101 @@
  */
 package org.gradle.testretry
 
-
 import spock.lang.Unroll
+
+import javax.annotation.Nullable
 
 class FilterFuncTest extends AbstractGeneralPluginFuncTest {
 
     @Unroll
-    def "can filter by class include pattern (gradle version #gradleVersion)"() {
-        when:
+    def "can filter what is retried (gradle version #gradleVersion)"() {
+        given:
         buildFile << """
             test.retry {
                 maxRetries = 2
-                filters.includeClasses.add("*Flaky*")
-            }
-            
-        """
-
-        writeTestSource """
-            package acme;
-
-            public class FlakyTests {
-                ${testAnnotation}
-                public void flakyTest() {
-                    ${flakyAssert()}
+                filter {
+                    includeClasses.add("*Included*")
+                    includeAnnotationClasses.add("*Included*")
+                    excludeClasses.add("*Excluded*")
+                    excludeAnnotationClasses.add("*Excluded*")
                 }
             }
         """
-
-        writeTestSource """
-            package acme;
-
-            public class FailedTests {
-                ${testAnnotation}
-                public void failedTest() {
-                    throw new RuntimeException("!");
-                }
-            }
-        """
-
-
-        then:
-        def result = gradleRunner(gradleVersion).buildAndFail()
 
         and:
-        result.output.count('failedTest FAILED') == 1
-        result.output.count('flakyTest FAILED') == 1
-        result.output.count('flakyTest PASSED') == 1
+        inheritedAnnotation("InheritedIncludedAnnotation")
+        inheritedAnnotation("InheritedExcludedAnnotation")
+        nonInheritedAnnotation("NonInheritedIncludedAnnotation")
+        nonInheritedAnnotation("NonInheritedExcludedAnnotation")
+
+        and:
+        def noRetry = []
+        def shouldRetry = []
+
+        shouldRetry << test("BaseIncludedTest", null, "InheritedIncludedAnnotation")
+        noRetry << test("BaseIncludedAndExcludedTest", "BaseIncludedTest", "InheritedExcludedAnnotation")
+        noRetry << test("IncludedAndExcludedInheritedTest", "BaseIncludedAndExcludedTest")
+        shouldRetry << test("IncludedNonInheritedTest", null, "NonInheritedIncludedAnnotation")
+        noRetry << test("ExcludedTest", null, "NonInheritedIncludedAnnotation")
+        noRetry << test("IncludeWithBadAnnotation", null, "InheritedExcludedAnnotation")
+
+        when:
+        def result = gradleRunner(gradleVersion).buildAndFail()
+
+        then:
+        noRetry.each {
+            assert result.output.count("acme.${it} > flakyTest FAILED") == 1
+            assert result.output.count("acme.${it} > flakyTest PASSED") == 0
+        }
+        shouldRetry.each {
+            assert result.output.count("acme.${it} > flakyTest FAILED") == 2
+            assert result.output.count("acme.${it} > flakyTest PASSED") == 1
+        }
 
         where:
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST
     }
 
+    private void nonInheritedAnnotation(String name) {
+        file("src/test/java/acme/${name}.java") << """
+            package acme;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+            
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ ElementType.TYPE })
+            public @interface $name { }
+        """
+    }
+
+    private void inheritedAnnotation(String name) {
+        file("src/test/java/${name}.java") << """
+            package acme;
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+            
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ ElementType.TYPE })
+            @java.lang.annotation.Inherited
+            public @interface $name { }
+        """
+    }
+
+    private String test(String name, @Nullable String superClass, String... annotations) {
+        file("src/test/java/acme/${name}.java") << """
+            package acme;
+            ${annotations.collect { "@$it" }.join("\n")}
+            public class $name ${superClass ? " extends $superClass" : ""} {
+                @org.junit.Test
+                public void flakyTest() {
+                    ${flakyAssert(name, 2)}
+                }
+            }
+        """
+        return name
+    }
 }

--- a/plugin/src/test/groovy/org/gradle/testretry/FilterFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/FilterFuncTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry
+
+
+import spock.lang.Unroll
+
+class FilterFuncTest extends AbstractGeneralPluginFuncTest {
+
+    @Unroll
+    def "can filter by class include pattern (gradle version #gradleVersion)"() {
+        when:
+        buildFile << """
+            test.retry {
+                maxRetries = 2
+                filters.includeClasses.add("*Flaky*")
+            }
+            
+        """
+
+        writeTestSource """
+            package acme;
+
+            public class FlakyTests {
+                ${testAnnotation}
+                public void flakyTest() {
+                    ${flakyAssert()}
+                }
+            }
+        """
+
+        writeTestSource """
+            package acme;
+
+            public class FailedTests {
+                ${testAnnotation}
+                public void failedTest() {
+                    throw new RuntimeException("!");
+                }
+            }
+        """
+
+
+        then:
+        def result = gradleRunner(gradleVersion).buildAndFail()
+
+        and:
+        result.output.count('failedTest FAILED') == 1
+        result.output.count('flakyTest FAILED') == 1
+        result.output.count('flakyTest PASSED') == 1
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+
+}

--- a/plugin/src/test/groovy/org/gradle/testretry/internal/filter/AnnotationInspectorImplTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/internal/filter/AnnotationInspectorImplTest.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradle.testretry.internal.filter
 
 import org.gradle.testkit.runner.GradleRunner

--- a/plugin/src/test/groovy/org/gradle/testretry/internal/filter/AnnotationInspectorImplTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/internal/filter/AnnotationInspectorImplTest.groovy
@@ -1,0 +1,104 @@
+package org.gradle.testretry.internal.filter
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testretry.internal.testsreader.TestsReader
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import javax.annotation.Nullable
+
+class AnnotationInspectorImplTest extends Specification {
+
+    @Rule
+    TemporaryFolder dir = new TemporaryFolder()
+
+    AnnotationInspector inspector
+
+    def setup() {
+        def settingsFile = dir.newFile('settings.gradle')
+        settingsFile << "rootProject.name = 'hello-world'"
+        def buildFile = dir.newFile('build.gradle')
+        buildFile << "plugins { id 'java' }"
+    }
+
+    def "finds annotations"() {
+        given:
+        nonInheritedAnnotation("AN1")
+        nonInheritedAnnotation("AN2")
+        nonInheritedAnnotation("AN3")
+        inheritedAnnotation("AI1")
+        inheritedAnnotation("AI2")
+        inheritedAnnotation("AI3")
+
+        classWithAnnotations("NoAnnotationBase", null)
+        classWithAnnotations("IncludeAnnotationBase", null, "AN1", "AI1")
+        classWithAnnotations("IncludeAnnotationChild", "IncludeAnnotationBase", "AN2", "AI2")
+        classWithAnnotations("IncludeAnnotationChildChild", "IncludeAnnotationChild")
+        classWithAnnotations("IncludeAnnotationChildChildChild", "IncludeAnnotationChildChild")
+
+        expect:
+        annotationsOf("NoAnnotationBase").empty
+        annotationsOf("NotExist").empty
+        annotationsOf("IncludeAnnotationBase") == ["AI1", "AN1"]
+        annotationsOf("IncludeAnnotationChild") == ["AI1", "AI2", "AN2"]
+        annotationsOf("IncludeAnnotationChildChild") == ["AI1", "AI2"]
+        annotationsOf("IncludeAnnotationChildChildChild") == ["AI1", "AI2"]
+    }
+
+    List<String> annotationsOf(String className) {
+        if (inspector == null) {
+            inspector = inspector()
+        }
+        inspector.getClassAnnotations(className).toList().sort()
+    }
+
+    File file(String path) {
+        def file = new File(dir.root, path)
+        assert file.parentFile.mkdirs() || file.parentFile.directory
+        assert file.createNewFile() || file.file
+        file
+    }
+
+    AnnotationInspector inspector() {
+        GradleRunner.create().withProjectDir(dir.root).withArguments("compileJava").build()
+        def reader = new TestsReader([new File(dir.root, "build/classes/java/main")].toSet(), [])
+        new AnnotationInspectorImpl(reader)
+    }
+
+    private void nonInheritedAnnotation(String name) {
+        file("src/main/java/${name}.java") << """
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+            
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ ElementType.TYPE })
+            public @interface $name { }
+        """
+    }
+
+    private void inheritedAnnotation(String name) {
+        file("src/main/java/${name}.java") << """
+            import java.lang.annotation.ElementType;
+            import java.lang.annotation.Retention;
+            import java.lang.annotation.RetentionPolicy;
+            import java.lang.annotation.Target;
+            
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target({ ElementType.TYPE })
+            @java.lang.annotation.Inherited
+            public @interface $name { }
+        """
+    }
+
+    private void classWithAnnotations(String name, @Nullable String superClass, String... annotations) {
+        file("src/main/java/${name}.java") << """
+            ${annotations.collect { "@$it" }.join("\n")}
+            class $name ${superClass ? " extends $superClass" : ""} {}
+        """
+
+    }
+
+}

--- a/plugin/src/test/groovy/org/gradle/testretry/internal/filter/GlobPatternTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/internal/filter/GlobPatternTest.groovy
@@ -1,0 +1,44 @@
+package org.gradle.testretry.internal.filter
+
+import spock.lang.Specification
+
+class GlobPatternTest extends Specification {
+
+    def "glob pattern matching"() {
+        expect:
+        with(GlobPattern.from("*")) {
+            matches "a"
+            matches "b"
+            matches "*"
+            matches " "
+        }
+        with(GlobPattern.from("**")) {
+            matches "a"
+            matches "b"
+            matches "*"
+            matches " "
+        }
+        with(GlobPattern.from(".")) {
+            matches "."
+            !matches("b")
+        }
+        with(GlobPattern.from("a*")) {
+            matches "a"
+            matches "ab"
+            !matches("ba")
+            !matches("b")
+        }
+        with(GlobPattern.from("a*a")) {
+            matches "aba"
+            matches "aa"
+            !matches("ba")
+            !matches("abc")
+        }
+        with(GlobPattern.from("**")) {
+            matches "aba"
+            matches "aa"
+            matches ""
+            matches "a"
+        }
+    }
+}

--- a/plugin/src/test/groovy/org/gradle/testretry/internal/filter/GlobPatternTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/internal/filter/GlobPatternTest.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradle.testretry.internal.filter
 
 import spock.lang.Specification

--- a/plugin/src/test/groovy/org/gradle/testretry/internal/filter/RetryFilterTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/internal/filter/RetryFilterTest.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gradle.testretry.internal.filter
 
 import spock.lang.Specification

--- a/plugin/src/test/groovy/org/gradle/testretry/internal/filter/RetryFilterTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/internal/filter/RetryFilterTest.groovy
@@ -1,0 +1,92 @@
+package org.gradle.testretry.internal.filter
+
+import spock.lang.Specification
+
+class RetryFilterTest extends Specification {
+
+    List<String> includeClasses = []
+    List<String> excludeClasses = []
+    List<String> includeAnnotations = []
+    List<String> excludeAnnotations = []
+
+    Map<String, List<String>> annotations = [:]
+
+    def "empty filter allows all"() {
+        expect:
+        with(filter()) {
+            canRetry("foo.bar")
+            canRetry("foo.baz")
+        }
+    }
+
+    def "must match include pattern"() {
+        when:
+        includeClasses << "1.*" << "2.*"
+
+        then:
+        with(filter()) {
+            canRetry("1.Test")
+            canRetry("2.Test")
+            !canRetry("3.Test")
+        }
+    }
+
+    def "must not match exclude pattern"() {
+        when:
+        includeClasses << "1.*" << "2.*"
+        excludeClasses << "2.*" << "3.*" << "z"
+
+        then:
+        with(filter()) {
+            canRetry("1.Test")
+            !canRetry("2.Test")
+            !canRetry("3.Test")
+            !canRetry("2.z")
+        }
+    }
+
+    def "must have include annotation"() {
+        when:
+        includeClasses << "*include*"
+        excludeClasses << "*exclude*"
+        includeAnnotations << "*include*"
+        annotations["include1"] = ["a"]
+        annotations["include2"] = ["a", "include"]
+
+        then:
+        with(filter()) {
+            !canRetry("include1")
+            canRetry("include2")
+            !canRetry("include3")
+        }
+    }
+
+    def "must not have exclude annotation"() {
+        when:
+        includeClasses << "*include*"
+        excludeClasses << "*exclude*"
+        includeAnnotations << "*include*"
+        excludeAnnotations << "*exclude*"
+        annotations["include1"] = ["a"]
+        annotations["include2"] = ["a", "include", "exclude"]
+        annotations["include3"] = ["a", "include"]
+
+        then:
+        with(filter()) {
+            !canRetry("include1")
+            !canRetry("include2")
+            canRetry("include3")
+            !canRetry("include4")
+        }
+    }
+
+    RetryFilter filter() {
+        new RetryFilter(
+            { annotations.getOrDefault(it, []).toSet() },
+            includeClasses,
+            includeAnnotations,
+            excludeClasses,
+            excludeAnnotations
+        )
+    }
+}

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4FuncTest.groovy
@@ -26,11 +26,6 @@ class JUnit4FuncTest extends AbstractFrameworkFuncTest {
         return 'java'
     }
 
-    @Override
-    String getTestAnnotation() {
-        return "@org.junit.Test"
-    }
-
     protected isRerunsAllParameterizedIterations() {
         false
     }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
@@ -25,11 +25,6 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
         return 'java'
     }
 
-    @Override
-    String getTestAnnotation() {
-        return "@org.junit.jupiter.api.Test"
-    }
-
     protected String afterClassErrorTestMethodName(String gradleVersion) {
         gradleVersion == "5.0" ? "classMethod" : "executionError"
     }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockFuncTest.groovy
@@ -27,11 +27,6 @@ class SpockFuncTest extends AbstractFrameworkFuncTest {
         return 'groovy'
     }
 
-    @Override
-    String getTestAnnotation() {
-        return ''
-    }
-
     boolean isRerunsParameterizedMethods() {
         true
     }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGFuncTest.groovy
@@ -25,11 +25,6 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
         return 'java'
     }
 
-    @Override
-    String getTestAnnotation() {
-        return "@org.testng.annotations.Test"
-    }
-
     @Unroll
     def "handles failure in #lifecycle (gradle version #gradleVersion)"() {
         given:


### PR DESCRIPTION
Supports class name patterns and annotation class name patterns.

Addresses https://github.com/gradle/test-retry-gradle-plugin/issues/43.