### PR TITLE
Do nothing on subsequent applications of this plugins

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/TestRetryPlugin.java
+++ b/plugin/src/main/java/org/gradle/testretry/TestRetryPlugin.java
@@ -39,9 +39,16 @@ public class TestRetryPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        if (pluginAlreadyApplied(project)) {
+            return;
+        }
+
         project.getTasks()
             .withType(Test.class)
             .configureEach(task -> configureTestTask(task, objectFactory, providerFactory));
     }
 
+    private static boolean pluginAlreadyApplied(Project project) {
+        return project.getPlugins().stream().anyMatch(plugin -> plugin.getClass().getName().equals(TestRetryPlugin.class.getName()));
+    }
 }


### PR DESCRIPTION
This change prevents multiple applications of this plugin from
multiple classloaders from raising errors by checking whether a
plugin with the same qualified class name is already applied to the
given project, and returning early if so.

Issue: #106