### PR TITLE
Add option to force entire test class to be retried

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -146,6 +146,15 @@ public interface TestRetryTaskExtension {
     Property<Integer> getMaxFailures();
 
     /**
+     * Whether test classes should be retried in entirety, or if individual tests methods can be retried.
+     * <p>
+     * This setting defaults to {@code false}, meaning that only the test methods that actually fail will be retried.
+     *
+     * @return whether individual test methods or entire test classes should be retried
+     */
+    Property<Boolean> getRetryEntireTestClass();
+
+    /**
      * The filter for specifying which tests may be retried.
      */
     Filter getFilter();

--- a/plugin/src/main/java/org/gradle/testretry/TestRetryTaskExtension.java
+++ b/plugin/src/main/java/org/gradle/testretry/TestRetryTaskExtension.java
@@ -70,6 +70,15 @@ public interface TestRetryTaskExtension {
     Property<Integer> getMaxFailures();
 
     /**
+     * Whether test classes should be retried in entirety, or if individual tests methods can be retried.
+     * <p>
+     * This setting defaults to {@code false}, meaning that only the test methods that actually fail will be retried.
+     *
+     * @return whether individual test methods or entire test classes should be retried
+     */
+    Property<Boolean> getRetryEntireTestClass();
+
+    /**
      * The filter for specifying which tests may be retried.
      */
     Filter getFilter();

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/DefaultTestRetryTaskExtension.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/DefaultTestRetryTaskExtension.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
 
     private final Property<Boolean> failOnPassedAfterRetry;
+    private final Property<Boolean> retryEntireTestClass;
     private final Property<Integer> maxRetries;
     private final Property<Integer> maxFailures;
     private final Filter filter;
@@ -33,6 +34,7 @@ public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
     @Inject
     public DefaultTestRetryTaskExtension(ObjectFactory objects) {
         this.failOnPassedAfterRetry = objects.property(Boolean.class);
+        this.retryEntireTestClass = objects.property(Boolean.class);
         this.maxRetries = objects.property(Integer.class);
         this.maxFailures = objects.property(Integer.class);
         this.filter = new FilterImpl(objects);
@@ -40,6 +42,11 @@ public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
 
     public Property<Boolean> getFailOnPassedAfterRetry() {
         return failOnPassedAfterRetry;
+    }
+
+    @Override
+    public Property<Boolean> getRetryEntireTestClass() {
+        return retryEntireTestClass;
     }
 
     public Property<Integer> getMaxRetries() {

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
@@ -36,6 +36,7 @@ public final class TestRetryTaskExtensionAdapter {
     private static final int DEFAULT_MAX_RETRIES = 0;
     private static final int DEFAULT_MAX_FAILURES = 0;
     private static final boolean DEFAULT_FAIL_ON_PASSED_AFTER_RETRY = false;
+    private static final boolean DEFAULT_RETRY_ENTIRE_TEST_CLASS = false;
 
     private final ProviderFactory providerFactory;
     private final TestRetryTaskExtension extension;
@@ -60,6 +61,7 @@ public final class TestRetryTaskExtensionAdapter {
             extension.getMaxRetries().convention(DEFAULT_MAX_RETRIES);
             extension.getMaxFailures().convention(DEFAULT_MAX_FAILURES);
             extension.getFailOnPassedAfterRetry().convention(DEFAULT_FAIL_ON_PASSED_AFTER_RETRY);
+            extension.getRetryEntireTestClass().convention(DEFAULT_RETRY_ENTIRE_TEST_CLASS);
             extension.getFilter().getIncludeClasses().convention(Collections.emptySet());
             extension.getFilter().getIncludeAnnotationClasses().convention(Collections.emptySet());
             extension.getFilter().getExcludeClasses().convention(Collections.emptySet());
@@ -89,6 +91,10 @@ public final class TestRetryTaskExtensionAdapter {
 
     public boolean getFailOnPassedAfterRetry() {
         return read(extension.getFailOnPassedAfterRetry(), DEFAULT_FAIL_ON_PASSED_AFTER_RETRY);
+    }
+
+    public boolean getRetryEntireTestClass() {
+        return read(extension.getRetryEntireTestClass(), DEFAULT_RETRY_ENTIRE_TEST_CLASS);
     }
 
     public int getMaxRetries() {

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -52,6 +52,7 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
         this.testTask = task;
         this.frameworkTemplate = new TestFrameworkTemplate(
             testTask,
+            extension,
             instantiator,
             objectFactory
         );

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/TestFilterBuilder.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/TestFilterBuilder.java
@@ -20,9 +20,18 @@ import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
 public final class TestFilterBuilder {
 
     private final DefaultTestFilter filter = new DefaultTestFilter();
+    private final boolean alwaysIncludeEntireTestClass;
+
+    public TestFilterBuilder(boolean alwaysIncludeEntireTestClass) {
+        this.alwaysIncludeEntireTestClass = alwaysIncludeEntireTestClass;
+    }
 
     public void test(String className, String methodName) {
-        filter.includeTest(className, methodName);
+        if (alwaysIncludeEntireTestClass) {
+            clazz(className);
+        } else {
+            filter.includeTest(className, methodName);
+        }
     }
 
     public void clazz(String className) {

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/TestFrameworkTemplate.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/TestFrameworkTemplate.java
@@ -18,23 +18,26 @@ package org.gradle.testretry.internal.executer;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.testretry.internal.config.TestRetryTaskExtensionAdapter;
 import org.gradle.testretry.internal.testsreader.TestsReader;
 
 public class TestFrameworkTemplate {
 
     public final Test task;
+    public final TestRetryTaskExtensionAdapter extension;
     public final Instantiator instantiator;
     public final ObjectFactory objectFactory;
     public final TestsReader testsReader;
 
-    public TestFrameworkTemplate(Test task, Instantiator instantiator, ObjectFactory objectFactory) {
+    public TestFrameworkTemplate(Test task, TestRetryTaskExtensionAdapter extension, Instantiator instantiator, ObjectFactory objectFactory) {
         this.task = task;
+        this.extension = extension;
         this.instantiator = instantiator;
         this.objectFactory = objectFactory;
         this.testsReader = new TestsReader(task.getTestClassesDirs().getFiles(), task.getClasspath());
     }
 
     public TestFilterBuilder filterBuilder() {
-        return new TestFilterBuilder();
+        return new TestFilterBuilder(extension.getRetryEntireTestClass());
     }
 }

--- a/plugin/src/test/groovy/org/gradle/testretry/AbstractGeneralPluginFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/AbstractGeneralPluginFuncTest.groovy
@@ -32,6 +32,24 @@ abstract class AbstractGeneralPluginFuncTest extends AbstractPluginFuncTest {
         """
     }
 
+    protected void mixedTest() {
+        writeTestSource """
+            package acme;
+
+            import static org.junit.Assert.assertTrue;
+
+            public class MixedTests {
+                @org.junit.Test
+                public void successTest() {}
+
+                @org.junit.Test
+                public void failedTest() {
+                    assertTrue(false);
+                }
+            }
+        """
+    }
+
     protected void failedTest() {
         writeTestSource """
             package acme;

--- a/plugin/src/test/groovy/org/gradle/testretry/AbstractPluginFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/AbstractPluginFuncTest.groovy
@@ -173,9 +173,10 @@ abstract class AbstractPluginFuncTest extends Specification {
         xml.'**'.find { it.name() == 'testsuite' && it.@name == "acme.${testClazz}" && it.@tests == "${expectedFailCount + expectedSuccessCount}" }
 
         // assert details
-        assert xml.'**'.findAll { it.name() == 'testcase' && it.@classname == "acme.${testClazz}" && it.@name == testName }
-        assert xml.'**'.findAll { it.name() == 'testcase' && it.@classname == "acme.${testClazz}" && !it.failure.isEmpty() }.size() == expectedFailCount
-        assert xml.'**'.findAll { it.name() == 'testcase' && it.@classname == "acme.${testClazz}" && it.failure.isEmpty() }.size() == expectedSuccessCount
+        def testDetails = xml.'**'.findAll { it.name() == 'testcase' && it.@classname == "acme.${testClazz}" && it.@name == testName }
+        assert testDetails
+        assert testDetails.findAll { it.failure.isEmpty() }.size() == expectedSuccessCount
+        assert testDetails.findAll { !it.failure.isEmpty() }.size() == expectedFailCount
         true
     }
 


### PR DESCRIPTION
In certain circumstances, tests may be structured in a way that makes them more likely to succeed when the entire test class is re-executed.  This commit adds a new option to enable this behaviour.