### PR TITLE
Add retryOnClassLevel option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -120,6 +120,17 @@ public interface TestRetryTaskExtension {
      */
     Property<Boolean> getFailOnPassedAfterRetry();
 
+
+    /**
+     * If tests should always be retried on a class level.
+     * <p>
+     * This setting defaults to {@code false},
+     * which results in retrying the failed method instead of the entire class.
+     *
+     * @return if tests should always be retried on a class level
+     */
+    Property<Boolean> getRetryOnClassLevel();
+
     /**
      * The maximum number of times to retry an individual test.
      * <p>

--- a/plugin/src/main/java/org/gradle/testretry/TestRetryTaskExtension.java
+++ b/plugin/src/main/java/org/gradle/testretry/TestRetryTaskExtension.java
@@ -45,6 +45,16 @@ public interface TestRetryTaskExtension {
     Property<Boolean> getFailOnPassedAfterRetry();
 
     /**
+     * If tests should always be retried on a class level.
+     * <p>
+     * This setting defaults to {@code false},
+     * which results in retrying the failed method instead of the entire class.
+     *
+     * @return if tests should always be retried on a class level
+     */
+    Property<Boolean> getRetryOnClassLevel();
+
+    /**
      * The maximum number of times to retry an individual test.
      * <p>
      * This setting defaults to {@code 0}, which results in no retries.

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/DefaultTestRetryTaskExtension.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/DefaultTestRetryTaskExtension.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
 
     private final Property<Boolean> failOnPassedAfterRetry;
+    private final Property<Boolean> retryOnClassLevel;
     private final Property<Integer> maxRetries;
     private final Property<Integer> maxFailures;
     private final Filter filter;
@@ -33,6 +34,7 @@ public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
     @Inject
     public DefaultTestRetryTaskExtension(ObjectFactory objects) {
         this.failOnPassedAfterRetry = objects.property(Boolean.class);
+        this.retryOnClassLevel = objects.property(Boolean.class);
         this.maxRetries = objects.property(Integer.class);
         this.maxFailures = objects.property(Integer.class);
         this.filter = new FilterImpl(objects);
@@ -40,6 +42,10 @@ public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
 
     public Property<Boolean> getFailOnPassedAfterRetry() {
         return failOnPassedAfterRetry;
+    }
+
+    public Property<Boolean> getRetryOnClassLevel() {
+        return retryOnClassLevel;
     }
 
     public Property<Integer> getMaxRetries() {

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
@@ -36,6 +36,7 @@ public final class TestRetryTaskExtensionAdapter {
     private static final int DEFAULT_MAX_RETRIES = 0;
     private static final int DEFAULT_MAX_FAILURES = 0;
     private static final boolean DEFAULT_FAIL_ON_PASSED_AFTER_RETRY = false;
+    private static final boolean DEFAULT_RETRY_ON_CLASS_LEVEL = false;
 
     private final ProviderFactory providerFactory;
     private final TestRetryTaskExtension extension;
@@ -60,6 +61,7 @@ public final class TestRetryTaskExtensionAdapter {
             extension.getMaxRetries().convention(DEFAULT_MAX_RETRIES);
             extension.getMaxFailures().convention(DEFAULT_MAX_FAILURES);
             extension.getFailOnPassedAfterRetry().convention(DEFAULT_FAIL_ON_PASSED_AFTER_RETRY);
+            extension.getRetryOnClassLevel().convention(DEFAULT_RETRY_ON_CLASS_LEVEL);
             extension.getFilter().getIncludeClasses().convention(Collections.emptySet());
             extension.getFilter().getIncludeAnnotationClasses().convention(Collections.emptySet());
             extension.getFilter().getExcludeClasses().convention(Collections.emptySet());
@@ -89,6 +91,24 @@ public final class TestRetryTaskExtensionAdapter {
 
     public boolean getFailOnPassedAfterRetry() {
         return read(extension.getFailOnPassedAfterRetry(), DEFAULT_FAIL_ON_PASSED_AFTER_RETRY);
+    }
+
+    Callable<Provider<Boolean>> getRetryOnClassLevelInput() {
+        if (useConventions) {
+            return extension::getRetryOnClassLevel;
+        } else {
+            return () -> {
+                if (extension.getRetryOnClassLevel().isPresent()) {
+                    return extension.getRetryOnClassLevel();
+                } else {
+                    return providerFactory.provider(TestRetryTaskExtensionAdapter.this::getRetryOnClassLevel);
+                }
+            };
+        }
+    }
+
+    public boolean getRetryOnClassLevel() {
+        return read(extension.getRetryOnClassLevel(), DEFAULT_RETRY_ON_CLASS_LEVEL);
     }
 
     public int getMaxRetries() {

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -47,6 +47,7 @@ public final class TestTaskConfigurer {
         TestRetryTaskExtensionAdapter adapter = new TestRetryTaskExtensionAdapter(providerFactory, extension, gradleVersion);
 
         test.getInputs().property("retry.failOnPassedAfterRetry", adapter.getFailOnPassedAfterRetryInput());
+        test.getInputs().property("retry.retryOnClassLevel", adapter.getRetryOnClassLevelInput());
 
         Provider<Boolean> isDeactivatedByTestDistributionPlugin =
             shouldTestRetryPluginBeDeactivated(test, objectFactory, providerFactory, gradleVersion);

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -59,7 +59,8 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
             instantiator,
             objectFactory,
             testClassesDir,
-            resolvedClasspath
+            resolvedClasspath,
+            extension
         );
     }
 

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/TestFrameworkTemplate.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/TestFrameworkTemplate.java
@@ -18,6 +18,7 @@ package org.gradle.testretry.internal.executer;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.testretry.internal.config.TestRetryTaskExtensionAdapter;
 import org.gradle.testretry.internal.testsreader.TestsReader;
 
 import java.io.File;
@@ -29,12 +30,14 @@ public class TestFrameworkTemplate {
     public final Instantiator instantiator;
     public final ObjectFactory objectFactory;
     public final TestsReader testsReader;
+    public final TestRetryTaskExtensionAdapter extension;
 
-    public TestFrameworkTemplate(Test task, Instantiator instantiator, ObjectFactory objectFactory, Set<File> testClassesDir, Set<File> resolvedClasspath) {
+    public TestFrameworkTemplate(Test task, Instantiator instantiator, ObjectFactory objectFactory, Set<File> testClassesDir, Set<File> resolvedClasspath, TestRetryTaskExtensionAdapter extension) {
         this.task = task;
         this.instantiator = instantiator;
         this.objectFactory = objectFactory;
         this.testsReader = new TestsReader(testClassesDir, resolvedClasspath);
+        this.extension = extension;
     }
 
     public TestFilterBuilder filterBuilder() {

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
@@ -16,6 +16,7 @@
 package org.gradle.testretry.internal.executer.framework;
 
 import org.gradle.testretry.internal.executer.TestFilterBuilder;
+import org.gradle.testretry.internal.executer.TestFrameworkTemplate;
 import org.gradle.testretry.internal.executer.TestNames;
 import org.gradle.testretry.internal.testsreader.TestsReader;
 import org.slf4j.Logger;
@@ -46,18 +47,23 @@ abstract class BaseJunitTestFrameworkStrategy implements TestFrameworkStrategy {
         return ERROR_SYNTHETIC_TEST_NAMES.contains(testName);
     }
 
-    protected void addFilters(TestFilterBuilder filters, TestsReader testsReader, TestNames failedTests, boolean canRunParameterizedSpockMethods) {
+    protected void addFilters(TestFilterBuilder filters, TestFrameworkTemplate template, TestNames failedTests, boolean canRunParameterizedSpockMethods) {
         failedTests.stream()
             .forEach(entry -> {
                 String className = entry.getKey();
                 Set<String> tests = entry.getValue();
+
+                if (template.extension.getRetryOnClassLevel()) {
+                    filters.clazz(className);
+                    return;
+                }
 
                 if (tests.stream().anyMatch(ERROR_SYNTHETIC_TEST_NAMES::contains)) {
                     filters.clazz(className);
                     return;
                 }
 
-                if (processSpockTest(filters, testsReader, canRunParameterizedSpockMethods, className, tests)) {
+                if (processSpockTest(filters, template.testsReader, canRunParameterizedSpockMethods, className, tests)) {
                     return;
                 }
 

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/Junit5TestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/Junit5TestFrameworkStrategy.java
@@ -27,7 +27,7 @@ final class Junit5TestFrameworkStrategy extends BaseJunitTestFrameworkStrategy {
     @Override
     public TestFramework createRetrying(TestFrameworkTemplate template, TestNames failedTests) {
         TestFilterBuilder filters = template.filterBuilder();
-        addFilters(filters, template.testsReader, failedTests, false);
+        addFilters(filters, template, failedTests, false);
         JUnitPlatformTestFramework newFramework = new JUnitPlatformTestFramework(filters.build());
         copyTestOptions((JUnitPlatformOptions) template.task.getTestFramework().getOptions(), newFramework.getOptions());
         return newFramework;

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/JunitTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/JunitTestFrameworkStrategy.java
@@ -27,7 +27,7 @@ final class JunitTestFrameworkStrategy extends BaseJunitTestFrameworkStrategy {
     @Override
     public TestFramework createRetrying(TestFrameworkTemplate template, TestNames failedTests) {
         TestFilterBuilder filters = template.filterBuilder();
-        addFilters(filters, template.testsReader, failedTests, true);
+        addFilters(filters, template, failedTests, true);
         JUnitTestFramework testFramework = new JUnitTestFramework(template.task, filters.build());
         copyTestOptions((JUnitOptions) template.task.getTestFramework().getOptions(), testFramework.getOptions());
         return testFramework;

--- a/plugin/src/test/groovy/org/gradle/testretry/AbstractPluginFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/AbstractPluginFuncTest.groovy
@@ -173,9 +173,8 @@ abstract class AbstractPluginFuncTest extends Specification {
         xml.'**'.find { it.name() == 'testsuite' && it.@name == "acme.${testClazz}" && it.@tests == "${expectedFailCount + expectedSuccessCount}" }
 
         // assert details
-        assert xml.'**'.findAll { it.name() == 'testcase' && it.@classname == "acme.${testClazz}" && it.@name == testName }
-        assert xml.'**'.findAll { it.name() == 'testcase' && it.@classname == "acme.${testClazz}" && !it.failure.isEmpty() }.size() == expectedFailCount
-        assert xml.'**'.findAll { it.name() == 'testcase' && it.@classname == "acme.${testClazz}" && it.failure.isEmpty() }.size() == expectedSuccessCount
+        assert xml.'**'.findAll { it.name() == 'testcase' && it.@classname == "acme.${testClazz}" && it.@name == testName && !it.failure.isEmpty() }.size() == expectedFailCount
+        assert xml.'**'.findAll { it.name() == 'testcase' && it.@classname == "acme.${testClazz}" && it.@name == testName && it.failure.isEmpty() }.size() == expectedSuccessCount
         true
     }
 

--- a/plugin/src/test/groovy/org/gradle/testretry/RetryOnClassLevelTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/RetryOnClassLevelTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry
+
+class RetryOnClassLevelTest extends AbstractGeneralPluginFuncTest {
+
+    def "retries all test methods on failure"() {
+        given:
+        buildFile << """
+            test.retry.maxRetries = 1
+            test.retry.retryOnClassLevel = true
+        """
+
+        writeTestSource """
+            package acme;
+
+            public class CombinedTests {
+                @org.junit.Test
+                public void ok() {}
+
+                @org.junit.Test
+                public void flaky() {
+                    ${flakyAssert()}
+                }
+            }
+        """
+
+        when:
+        def result = gradleRunner(gradleVersion).build()
+
+        then:
+        result.output.count('PASSED') == 3
+        result.output.count('FAILED') == 1
+
+        assertTestReportContains("CombinedTests", reportedTestName("flaky"), 1, 1)
+        assertTestReportContains("CombinedTests", reportedTestName("ok"), 2, 0)
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+}


### PR DESCRIPTION
I have tests which need to be retried on class level (integration tests, with individual steps being ordered using `@Order`). This PR adds a new `retryOnClassLevel` property that always retries the whole test class.