### PR TITLE
Fix breaking change introduced in Gradle 7.6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.6-20220429113506+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -120,12 +120,16 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
     }
 
     public void failWithNonRetriedTestsIfAny() {
-        if (extension.getSimulateNotRetryableTest() || lastResult != null && !lastResult.nonRetriedTests.isEmpty()) {
+        if (extension.getSimulateNotRetryableTest() || hasNonRetriedTests()) {
             throw new IllegalStateException("org.gradle.test-retry was unable to retry the following test methods, which is unexpected. Please file a bug report at https://github.com/gradle/test-retry-gradle-plugin/issues" +
                 lastResult.nonRetriedTests.stream()
                     .flatMap(entry -> entry.getValue().stream().map(methodName -> "   " + entry.getKey() + "#" + methodName))
                     .collect(Collectors.joining("\n", "\n", "\n")));
         }
+    }
+
+    private boolean hasNonRetriedTests() {
+        return lastResult != null && !lastResult.nonRetriedTests.isEmpty();
     }
 
     private JvmTestExecutionSpec createRetryJvmExecutionSpec(JvmTestExecutionSpec spec, TestFramework retryTestFramework) {

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -120,7 +120,7 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
     }
 
     public void failWithNonRetriedTestsIfAny() {
-        if (extension.getSimulateNotRetryableTest() || (lastResult != null && !lastResult.nonRetriedTests.isEmpty())) {
+        if (extension.getSimulateNotRetryableTest() || lastResult != null && !lastResult.nonRetriedTests.isEmpty()) {
             throw new IllegalStateException("org.gradle.test-retry was unable to retry the following test methods, which is unexpected. Please file a bug report at https://github.com/gradle/test-retry-gradle-plugin/issues" +
                 lastResult.nonRetriedTests.stream()
                     .flatMap(entry -> entry.getValue().stream().map(methodName -> "   " + entry.getKey() + "#" + methodName))

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
@@ -171,7 +171,11 @@ final class RetryTestResultProcessor implements TestResultProcessor {
     private boolean lastRun() {
         return currentRoundFailedTests.isEmpty()
             || lastRetry
-            || maxFailures > 0 && currentRoundFailedTests.size() >= maxFailures;
+            || currentRoundFailedTestsExceedsMaxFailures();
+    }
+
+    private boolean currentRoundFailedTestsExceedsMaxFailures() {
+        return maxFailures > 0 && currentRoundFailedTests.size() >= maxFailures;
     }
 
     public RoundResult getResult() {

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
@@ -171,7 +171,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
     private boolean lastRun() {
         return currentRoundFailedTests.isEmpty()
             || lastRetry
-            || (maxFailures > 0 && currentRoundFailedTests.size() >= maxFailures);
+            || maxFailures > 0 && currentRoundFailedTests.size() >= maxFailures;
     }
 
     public RoundResult getResult() {

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
@@ -25,7 +25,6 @@ import org.gradle.testretry.internal.executer.framework.TestFrameworkStrategy;
 import org.gradle.testretry.internal.filter.RetryFilter;
 import org.gradle.testretry.internal.testsreader.TestsReader;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
@@ -136,7 +135,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
         try {
             Method failureMethod = delegate.getClass().getMethod("failure", Object.class, Throwable.class);
             failureMethod.invoke(delegate, testId, throwable);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
     }

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
@@ -41,6 +41,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
     private final int maxFailures;
     private boolean lastRetry;
     private boolean hasRetryFilteredFailures;
+    private Method failureMethod;
 
     private final Map<Object, TestDescriptorInternal> activeDescriptorsById = new HashMap<>();
 
@@ -133,11 +134,18 @@ final class RetryTestResultProcessor implements TestResultProcessor {
         // on the delegate via reflection.
         failure(testId);
         try {
-            Method failureMethod = delegate.getClass().getMethod("failure", Object.class, Throwable.class);
+            Method failureMethod = lookupFailureMethod();
             failureMethod.invoke(delegate, testId, throwable);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private Method lookupFailureMethod() throws ReflectiveOperationException {
+        if (failureMethod == null) {
+            failureMethod = delegate.getClass().getMethod("failure", Object.class, Throwable.class);
+        }
+        return failureMethod;
     }
 
     @Override


### PR DESCRIPTION
Gradle 7.6 broke the internal `TestResultProcessor` API as it changed the signature of the `failure()` method. This PR fixes the compilation error and maintains compatibility with existing Gradle versions by using reflection.