### PR TITLE
Retry on TestNG BeforeMethod/AfterMethod failure

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/TestNgClassVisitor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/TestNgClassVisitor.java
@@ -37,8 +37,10 @@ final class TestNgClassVisitor extends TestsReader.Visitor<TestNgClassVisitor.Cl
     private static final List<String> LIFECYCLE_ANNOTATION_DESCRIPTORS = Arrays.asList(
         "Lorg/testng/annotations/BeforeClass;",
         "Lorg/testng/annotations/BeforeTest;",
+        "Lorg/testng/annotations/BeforeMethod;",
         "Lorg/testng/annotations/AfterTest;",
-        "Lorg/testng/annotations/AfterClass;"
+        "Lorg/testng/annotations/AfterClass;",
+        "Lorg/testng/annotations/AfterMethod;"
     );
 
     private String currentMethod;

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGFuncTest.groovy
@@ -64,7 +64,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
         where:
         [gradleVersion, lifecycle] << GroovyCollections.combinations((Iterable) [
             GRADLE_VERSIONS_UNDER_TEST,
-            ['BeforeClass', 'BeforeTest', 'AfterClass', 'AfterTest']
+            ['BeforeClass', 'BeforeTest', 'BeforeMethod', 'AfterClass', 'AfterTest', 'AfterMethod']
         ])
         // Note: we don't handle BeforeSuite AfterSuite
     }


### PR DESCRIPTION
Fix "org.gradle.test-retry was unable to retry the following test methods" that are annotated with TestNG BeforeMethod/AfterMethod by retrying the entire class. The entire class is retried because TestNG skips tests on lifecycle method failure.
