### PR TITLE
Update readme with workaround of unsupported test frameworks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -255,6 +255,22 @@ The plugin supports retrying Spock `@Stepwise` tests and TestNG `@Test(dependsOn
 * Upstream tests (those that the failed test depends on) are run because a flaky test may depend on state from the prior execution of an upstream test.
 * Downstream tests are run because a flaky test causes any downstream tests to be skipped in the initial test run.
 
+=== Projects with multiple test frameworks
+Some projects may use multiple test frameworks to execute tests. In the scenario where one of the test frameworks is not
+supported, and is providing test tasks extending from Gradle task `Test`, we can skip the configuration with:
+
+```
+tasks.withType(Test).configureEach {
+    if (testFramework !instanceof com.foo.UnsupportedTestFramework) {
+        retry {
+            maxRetries.set(1)
+            maxFailures.set(5)
+            failOnPassedAfterRetry.set(true)
+        }
+    }
+}
+```
+
 == Filtering
 
 By default, all tests are eligible for retrying.

--- a/README.adoc
+++ b/README.adoc
@@ -256,7 +256,7 @@ The plugin supports retrying Spock `@Stepwise` tests and TestNG `@Test(dependsOn
 * Downstream tests are run because a flaky test causes any downstream tests to be skipped in the initial test run.
 
 === Projects with multiple test frameworks
-Some projects may use multiple test frameworks to execute tests. In the scenario where one of the test frameworks is not
+Some projects may use multiple test tasks with different frameworks to execute tests. In the scenario where one of the test frameworks is not
 supported, and is providing test tasks extending from Gradle task `Test`, we can skip the configuration with:
 
 ```

--- a/README.adoc
+++ b/README.adoc
@@ -256,12 +256,12 @@ The plugin supports retrying Spock `@Stepwise` tests and TestNG `@Test(dependsOn
 * Downstream tests are run because a flaky test causes any downstream tests to be skipped in the initial test run.
 
 === Projects with multiple test frameworks
-Some projects may use multiple test tasks with different frameworks to execute tests. In the scenario where one of the test frameworks is not
-supported, and is providing test tasks extending from Gradle task `Test`, we can skip the configuration with:
+Some projects may use multiple test tasks with different frameworks to execute tests. In the scenario where one of the test tasks is not
+supported, we can skip the configuration with:
 
 ```
 tasks.withType(Test).configureEach {
-    if (testFramework !instanceof com.foo.UnsupportedTestFramework) {
+    if (name != "unsupportedTestTaskUnitTest") {
         retry {
             maxRetries.set(1)
             maxFailures.set(5)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.6-20220429113506+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.6-20220822144040+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/TestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/TestFrameworkStrategy.java
@@ -24,11 +24,14 @@ import org.gradle.testretry.internal.executer.TestNames;
 import org.gradle.testretry.internal.testsreader.TestsReader;
 import org.gradle.util.GradleVersion;
 
+import javax.annotation.Nullable;
+
 /**
  * Instances are scoped to a test task execution and are reused between rounds.
  */
 public interface TestFrameworkStrategy {
 
+    @Nullable
     static TestFrameworkStrategy of(TestFramework testFramework) {
         if (testFramework instanceof JUnitTestFramework) {
             return new JunitTestFrameworkStrategy();
@@ -37,7 +40,7 @@ public interface TestFrameworkStrategy {
         } else if (testFramework instanceof TestNGTestFramework) {
             return new TestNgTestFrameworkStrategy();
         } else {
-            throw new UnsupportedOperationException("Unknown test framework: " + testFramework);
+            return null;
         }
     }
 

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/UnsupportedTestFrameworkFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/UnsupportedTestFrameworkFuncTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry.testframework
+
+import org.gradle.api.internal.tasks.testing.TestFramework
+import org.gradle.testretry.AbstractFrameworkFuncTest
+
+class UnsupportedTestFrameworkFuncTest extends AbstractFrameworkFuncTest {
+
+    def "logs warning if test framework is unsupported"(String gradleVersion) {
+        given:
+        buildFile << """
+            test.retry.maxRetries = 2
+            
+            class CustomTestFramework implements $TestFramework.name {
+                @Delegate 
+                private final $TestFramework.name delegate
+
+                CustomTestFramework($TestFramework.name delegate) {
+                    this.delegate = delegate
+                }
+            }
+            
+            test.useTestFramework(new CustomTestFramework(test.testFramework))
+        """
+
+        successfulTest()
+
+        when:
+        def runner = gradleRunner(gradleVersion as String)
+        def result = runner.build()
+
+        then:
+        result.output.contains("Test retry requested for task :test with unsupported test framework CustomTestFramework - failing tests will not be retried\n")
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+}


### PR DESCRIPTION
Update readme with workaround of unsupported test frameworks