### PR TITLE
#101 - Adds support for JUnitParams / JUnit4

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
@@ -108,8 +108,8 @@ abstract class BaseJunitTestFrameworkStrategy implements TestFrameworkStrategy {
     }
 
     private void addPotentiallyParameterizedSuffixed(TestFilterBuilder filters, String className, String name) {
-        // It's a common pattern to add all the parameters on the end of a literal method name with []
-        String strippedParameterName = name.replaceAll("(?:\\([^)]*?\\)|\\[[^]]*?])*$", "");
+        // It's a common pattern to add all the parameters on the end of a literal method name with [] or () or both
+        String strippedParameterName = name.replaceAll("(?:\\([^)]*?\\)|\\[[^]]*?]|\\s)*$", "");
         filters.test(className, strippedParameterName);
         filters.test(className, name);
     }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4FuncTest.groovy
@@ -350,7 +350,6 @@ class JUnit4FuncTest extends AbstractFrameworkFuncTest {
 				@Parameters({
 					"0, true",
 					"1, false" })
-				@TestCaseName("{method}[{index}: {method}({0})={1}]")
 				public void test(int input, boolean expected) {
 					assertTrue(expected);
 				}
@@ -361,8 +360,8 @@ class JUnit4FuncTest extends AbstractFrameworkFuncTest {
 		def result = gradleRunner(gradleVersion).buildAndFail()
 
 		then:
-		result.output.count('test[0: test(0)=true] PASSED') == 2
-		result.output.count('test[1: test(1)=false] FAILED') == 2
+		result.output.count('test(0, true) [0] PASSED') == 2
+		result.output.count('test(1, false) [1] FAILED') == 2
 
 		where:
 		gradleVersion << GRADLE_VERSIONS_UNDER_TEST


### PR DESCRIPTION
As described in #101, using the plugin with [JUnitParams](https://github.com/Pragmatists/JUnitParams) results in a failure message. 

`org.gradle.test-retry was unable to retry the following test methods, which is unexpected. Please file a bug report at https://github.com/gradle/test-retry-gradle-plugin/issues`

This PR updates the regex used to extract the Java method name from the JUnit test name. It also adds a test / example for using JUnitParams tests with the plugin  