### PR TITLE
Decouple retry extension

### DIFF
--- a/buildSrc/src/main/groovy/org/gradle/testretry/build/GradleVersionData.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testretry/build/GradleVersionData.groovy
@@ -1,9 +1,13 @@
 package org.gradle.testretry.build
 
 import groovy.json.JsonSlurper
-import org.gradle.util.VersionNumber
+import org.gradle.util.GradleVersion
+
+import java.util.regex.Pattern
 
 class GradleVersionData {
+
+    static final Pattern MAJOR_AND_MINOR_VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+).*")
 
     static List<String> getNightlyVersions() {
         def releaseNightly = getLatestReleaseNightly()
@@ -19,20 +23,43 @@ class GradleVersionData {
     }
 
     static List<String> getReleasedVersions() {
+        def GRADLE_5 = GradleVersion.version("5.0")
+        GRADLE_5.version
+
         new JsonSlurper().parse(new URL("https://services.gradle.org/versions/all"))
             .findAll { !it.nightly && !it.snapshot } // filter out snapshots and nightlies
             .findAll { !it.rcFor || it.activeRc } // filter out inactive rcs
             .findAll { !it.milestoneFor } // filter out milestones
-            .<String, VersionNumber, String>collectEntries { [(it.version): VersionNumber.parse(it.version as String)] }
-            .findAll { it.value.major >= 5 } // only 5.0 and above
-            .inject([] as List<Map.Entry<String, VersionNumber>>) { releasesToTest, version -> // only test against latest patch versions
-                if (!releasesToTest.any { it.value.major == version.value.major && it.value.minor == version.value.minor }) {
+            .<String, GradleVersion, String>collectEntries { [(it.version): GradleVersion.version(it.version as String)] }
+            .findAll { it.value >= GRADLE_5 } // only 5.0 and above
+            .inject([] as List<Map.Entry<String, GradleVersion>>) { releasesToTest, version -> // only test against latest patch versions
+                if (!releasesToTest.any { major(it.value) == major(version.value) && minor(it.value) == minor(version.value) }) {
                     releasesToTest + version
                 } else {
                     releasesToTest
                 }
             }
             .collect { it.key.toString() }
+    }
+
+    static int major(GradleVersion gradle) {
+        def version = gradle.version
+        def matcher = MAJOR_AND_MINOR_VERSION_PATTERN.matcher(version)
+        if (matcher.matches()) {
+            return Integer.parseInt(matcher.group(1))
+        } else {
+            throw new IllegalArgumentException("Failed to determine major version for version ${version}")
+        }
+    }
+
+    static int minor(GradleVersion gradle) {
+        def version = gradle.version
+        def matcher = MAJOR_AND_MINOR_VERSION_PATTERN.matcher(version)
+        if (matcher.matches()) {
+            return Integer.parseInt(matcher.group(2))
+        } else {
+            throw new IllegalArgumentException("Failed to determine major version for version ${version}")
+        }
     }
 
 }

--- a/buildSrc/src/main/groovy/org/gradle/testretry/build/GradleVersionData.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testretry/build/GradleVersionData.groovy
@@ -24,7 +24,6 @@ class GradleVersionData {
 
     static List<String> getReleasedVersions() {
         def GRADLE_5 = GradleVersion.version("5.0")
-        GRADLE_5.version
 
         new JsonSlurper().parse(new URL("https://services.gradle.org/versions/all"))
             .findAll { !it.nightly && !it.snapshot } // filter out snapshots and nightlies

--- a/buildSrc/src/main/groovy/org/gradle/testretry/build/GradleVersionData.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testretry/build/GradleVersionData.groovy
@@ -7,7 +7,7 @@ import java.util.regex.Pattern
 
 class GradleVersionData {
 
-    static final Pattern MAJOR_AND_MINOR_VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+).*")
+    static final Pattern MAJOR_AND_MINOR_VERSION_PATTERN = ~/(?<major>\d+)\.(?<minor>\d+).*/
 
     static List<String> getNightlyVersions() {
         def releaseNightly = getLatestReleaseNightly()
@@ -42,23 +42,26 @@ class GradleVersionData {
     }
 
     static int major(GradleVersion gradle) {
-        def version = gradle.version
-        def matcher = MAJOR_AND_MINOR_VERSION_PATTERN.matcher(version)
-        if (matcher.matches()) {
-            return Integer.parseInt(matcher.group(1))
-        } else {
-            throw new IllegalArgumentException("Failed to determine major version for version ${version}")
-        }
+        extractedGroup(gradle, "major")
     }
 
     static int minor(GradleVersion gradle) {
+        extractedGroup(gradle, "minor")
+    }
+
+    static int extractedGroup(GradleVersion gradle, String groupName) {
         def version = gradle.version
         def matcher = MAJOR_AND_MINOR_VERSION_PATTERN.matcher(version)
         if (matcher.matches()) {
-            return Integer.parseInt(matcher.group(2))
+            try {
+                return Integer.parseInt(matcher.group(groupName))
+            } catch(RuntimeException exc) {
+                throw new IllegalArgumentException("Failed to determine ${groupName} group for version ${version}", exc)
+            }
         } else {
-            throw new IllegalArgumentException("Failed to determine major version for version ${version}")
+            throw new IllegalArgumentException("Failed to determine ${groupName} group for version ${version}")
         }
     }
 
 }
+

--- a/buildSrc/src/main/groovy/org/gradle/testretry/build/PluginsVersionData.groovy
+++ b/buildSrc/src/main/groovy/org/gradle/testretry/build/PluginsVersionData.groovy
@@ -1,11 +1,15 @@
 package org.gradle.testretry.build
 
+import groovy.transform.CompileStatic
 import groovy.xml.XmlSlurper
 
+@CompileStatic
 class PluginsVersionData {
 
     static String latestVersion(String group, String name) {
-        String url = "https://plugins.gradle.org/m2/${group.replace('.', '/')}/$name/maven-metadata.xml"
-        return new XmlSlurper().parse(url).version
+        def url = "https://plugins.gradle.org/m2/${group.replace('.', '/')}/$name/maven-metadata.xml"
+        def result = new XmlSlurper().parse(url)
+
+        result["version"]
     }
 }

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAccessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAccessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry.internal.config;
+
+import java.util.Set;
+
+public interface TestRetryTaskExtensionAccessor {
+
+    boolean getFailOnPassedAfterRetry();
+
+    int getMaxRetries();
+
+    int getMaxFailures();
+
+    Set<String> getIncludeClasses();
+
+    Set<String> getIncludeAnnotationClasses();
+
+    Set<String> getExcludeClasses();
+
+    Set<String> getExcludeAnnotationClasses();
+
+    boolean getSimulateNotRetryableTest();
+
+}

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
@@ -22,10 +22,10 @@ import org.gradle.api.provider.SetProperty;
 import org.gradle.testretry.TestRetryTaskExtension;
 import org.gradle.util.VersionNumber;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
+import static java.util.Collections.emptySet;
 import static org.gradle.testretry.internal.config.TestTaskConfigurer.supportsPropertyConventions;
 
 public final class TestRetryTaskExtensionAdapter implements TestRetryTaskExtensionAccessor {
@@ -60,10 +60,10 @@ public final class TestRetryTaskExtensionAdapter implements TestRetryTaskExtensi
             extension.getMaxRetries().convention(DEFAULT_MAX_RETRIES);
             extension.getMaxFailures().convention(DEFAULT_MAX_FAILURES);
             extension.getFailOnPassedAfterRetry().convention(DEFAULT_FAIL_ON_PASSED_AFTER_RETRY);
-            extension.getFilter().getIncludeClasses().convention(Collections.emptySet());
-            extension.getFilter().getIncludeAnnotationClasses().convention(Collections.emptySet());
-            extension.getFilter().getExcludeClasses().convention(Collections.emptySet());
-            extension.getFilter().getExcludeAnnotationClasses().convention(Collections.emptySet());
+            extension.getFilter().getIncludeClasses().convention(emptySet());
+            extension.getFilter().getIncludeAnnotationClasses().convention(emptySet());
+            extension.getFilter().getExcludeClasses().convention(emptySet());
+            extension.getFilter().getExcludeAnnotationClasses().convention(emptySet());
         } else {
             // https://github.com/gradle/gradle/issues/7485
             extension.getFilter().getIncludeClasses().empty();
@@ -104,22 +104,22 @@ public final class TestRetryTaskExtensionAdapter implements TestRetryTaskExtensi
 
     @Override
     public Set<String> getIncludeClasses() {
-        return read(extension.getFilter().getIncludeClasses(), Collections.emptySet());
+        return read(extension.getFilter().getIncludeClasses(), emptySet());
     }
 
     @Override
     public Set<String> getIncludeAnnotationClasses() {
-        return read(extension.getFilter().getIncludeAnnotationClasses(), Collections.emptySet());
+        return read(extension.getFilter().getIncludeAnnotationClasses(), emptySet());
     }
 
     @Override
     public Set<String> getExcludeClasses() {
-        return read(extension.getFilter().getExcludeClasses(), Collections.emptySet());
+        return read(extension.getFilter().getExcludeClasses(), emptySet());
     }
 
     @Override
     public Set<String> getExcludeAnnotationClasses() {
-        return read(extension.getFilter().getExcludeAnnotationClasses(), Collections.emptySet());
+        return read(extension.getFilter().getExcludeAnnotationClasses(), emptySet());
     }
 
     @Override

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
@@ -20,7 +20,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.testretry.TestRetryTaskExtension;
-import org.gradle.util.VersionNumber;
+import org.gradle.util.GradleVersion;
 
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -45,7 +45,7 @@ public final class TestRetryTaskExtensionAdapter implements TestRetryTaskExtensi
     public TestRetryTaskExtensionAdapter(
         ProviderFactory providerFactory,
         TestRetryTaskExtension extension,
-        VersionNumber gradleVersion
+        GradleVersion gradleVersion
     ) {
         this.providerFactory = providerFactory;
         this.extension = extension;

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Callable;
 
 import static org.gradle.testretry.internal.config.TestTaskConfigurer.supportsPropertyConventions;
 
-public final class TestRetryTaskExtensionAdapter {
+public final class TestRetryTaskExtensionAdapter implements TestRetryTaskExtensionAccessor {
 
     // for testing only
     public static final String SIMULATE_NOT_RETRYABLE_PROPERTY = "__org_gradle_testretry_simulate_not_retryable";
@@ -87,34 +87,42 @@ public final class TestRetryTaskExtensionAdapter {
         }
     }
 
+    @Override
     public boolean getFailOnPassedAfterRetry() {
         return read(extension.getFailOnPassedAfterRetry(), DEFAULT_FAIL_ON_PASSED_AFTER_RETRY);
     }
 
+    @Override
     public int getMaxRetries() {
         return read(extension.getMaxRetries(), DEFAULT_MAX_RETRIES);
     }
 
+    @Override
     public int getMaxFailures() {
         return read(extension.getMaxFailures(), DEFAULT_MAX_FAILURES);
     }
 
+    @Override
     public Set<String> getIncludeClasses() {
         return read(extension.getFilter().getIncludeClasses(), Collections.emptySet());
     }
 
+    @Override
     public Set<String> getIncludeAnnotationClasses() {
         return read(extension.getFilter().getIncludeAnnotationClasses(), Collections.emptySet());
     }
 
+    @Override
     public Set<String> getExcludeClasses() {
         return read(extension.getFilter().getExcludeClasses(), Collections.emptySet());
     }
 
+    @Override
     public Set<String> getExcludeAnnotationClasses() {
         return read(extension.getFilter().getExcludeAnnotationClasses(), Collections.emptySet());
     }
 
+    @Override
     public boolean getSimulateNotRetryableTest() {
         return simulateNotRetryableTest;
     }

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -28,7 +28,7 @@ import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.testretry.TestRetryTaskExtension;
 import org.gradle.testretry.internal.executer.RetryTestExecuter;
-import org.gradle.util.VersionNumber;
+import org.gradle.util.GradleVersion;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.InvocationTargetException;
@@ -36,11 +36,14 @@ import java.lang.reflect.Method;
 
 public final class TestTaskConfigurer {
 
+    private final static GradleVersion GRADLE_5_1 = GradleVersion.version("5.1");
+    private final static GradleVersion GRADLE_6_1 = GradleVersion.version("6.1");
+
     private TestTaskConfigurer() {
     }
 
     public static void configureTestTask(Test test, ObjectFactory objectFactory, ProviderFactory providerFactory) {
-        VersionNumber gradleVersion = VersionNumber.parse(test.getProject().getGradle().getGradleVersion());
+        GradleVersion gradleVersion = GradleVersion.current();
 
         TestRetryTaskExtension extension = objectFactory.newInstance(DefaultTestRetryTaskExtension.class);
 
@@ -62,7 +65,7 @@ public final class TestTaskConfigurer {
         Test test,
         ObjectFactory objectFactory,
         ProviderFactory providerFactory,
-        VersionNumber gradleVersion
+        GradleVersion gradleVersion
     ) {
         Provider<Boolean> result = providerFactory.provider(() -> callShouldTestRetryPluginBeDeactivated(test));
         if (supportsPropertyConventions(gradleVersion)) {
@@ -75,12 +78,12 @@ public final class TestTaskConfigurer {
         return result;
     }
 
-    public static boolean supportsPropertyConventions(VersionNumber gradleVersion) {
-        return gradleVersion.compareTo(VersionNumber.parse("5.1")) >= 0;
+    public static boolean supportsPropertyConventions(GradleVersion gradleVersion) {
+        return gradleVersion.compareTo(GRADLE_5_1) >= 0;
     }
 
-    private static boolean supportsFinalizeValueOnRead(VersionNumber gradleVersion) {
-        return gradleVersion.compareTo(VersionNumber.parse("6.1")) >= 0;
+    private static boolean supportsFinalizeValueOnRead(GradleVersion gradleVersion) {
+        return gradleVersion.compareTo(GRADLE_6_1) >= 0;
     }
 
     private static boolean callShouldTestRetryPluginBeDeactivated(Test test) {

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.testretry.internal.config.TestRetryTaskExtensionAdapter;
+import org.gradle.testretry.internal.config.TestRetryTaskExtensionAccessor;
 import org.gradle.testretry.internal.executer.framework.TestFrameworkStrategy;
 import org.gradle.testretry.internal.filter.AnnotationInspectorImpl;
 import org.gradle.testretry.internal.filter.RetryFilter;
@@ -38,7 +38,7 @@ import static org.gradle.testretry.internal.executer.framework.TestFrameworkStra
 public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RetryTestExecuter.class);
-    private final TestRetryTaskExtensionAdapter extension;
+    private final TestRetryTaskExtensionAccessor extension;
     private final TestExecuter<JvmTestExecutionSpec> delegate;
     private final Test testTask;
     private final TestFrameworkTemplate frameworkTemplate;
@@ -47,7 +47,7 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
 
     public RetryTestExecuter(
         Test task,
-        TestRetryTaskExtensionAdapter extension,
+        TestRetryTaskExtensionAccessor extension,
         TestExecuter<JvmTestExecutionSpec> delegate,
         Instantiator instantiator,
         ObjectFactory objectFactory,

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock2FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock2FuncTest.groovy
@@ -15,13 +15,13 @@
  */
 package org.gradle.testretry.testframework
 
-import org.gradle.util.VersionNumber
+import org.gradle.util.GradleVersion
 
 class Spock2FuncTest extends SpockBaseJunit5FuncTest {
 
     @Override
     boolean canTargetInheritedMethods(String gradleVersion) {
-        VersionNumber.parse(gradleVersion).major >= 7
+        GradleVersion.version(gradleVersion) >= GradleVersion.version("7.0")
     }
 
     @Override


### PR DESCRIPTION
This PR introduces a new interface for accessing properties on the `retry` extension. The `RetryTestExecuter` uses this interface now instead of `TestRetryTaskExtensionAdapter`.

Also, the usage of `org.gradle.util.VersionNumber` is removed, because it is deprecated in Gradle.
