### PR TITLE
Add Apache 2.0 licensing information for published pom.xml

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -108,6 +108,14 @@ publishing {
             artifact(shadowJar.get()) {
                 classifier = null
             }
+            pom {
+                licenses {
+                    license {
+                        name.set("Apache-2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+            }
         }
     }
     repositories {


### PR DESCRIPTION
The following change makes sure that the published `pom.xml` contains proper license information:

```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.gradle</groupId>
  <artifactId>test-retry-gradle-plugin</artifactId>
  <version>1.5.0-dev.18+snoopcheri.add.license.to.published.pom.b104056</version>
  <licenses>
    <license>
      <name>Apache-2.0</name>
      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
    </license>
  </licenses>
</project>
```
