### PR TITLE
Adjustment for creating `JvmTestExecutionSpec` when retrying tests and using Gradle 8

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.0-20221017221202+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.0-20221109235928+0000-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/JvmTestExecutionSpecFactory.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/JvmTestExecutionSpecFactory.java
@@ -15,9 +15,15 @@
  */
 package org.gradle.testretry.internal.executer;
 
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestFramework;
+import org.gradle.process.JavaForkOptions;
 import org.gradle.util.GradleVersion;
+
+import java.lang.reflect.Constructor;
+import java.util.Set;
 
 enum JvmTestExecutionSpecFactory {
 
@@ -31,41 +37,80 @@ enum JvmTestExecutionSpecFactory {
     FACTORY_FOR_GRADLE_OLDER_THAN_V8 {
         @Override
         JvmTestExecutionSpec createExecutionSpec(TestFramework testFramework, JvmTestExecutionSpec source) {
-            // This constructor is in Gradle 6.4+
-            return new JvmTestExecutionSpec(
-                testFramework,
-                source.getClasspath(),
-                source.getModulePath(),
-                source.getCandidateClassFiles(),
-                source.isScanForTestClasses(),
-                source.getTestClassesDirs(),
-                source.getPath(),
-                source.getIdentityPath(),
-                source.getForkEvery(),
-                source.getJavaForkOptions(),
-                source.getMaxParallelForks(),
-                source.getPreviousFailedTestClasses()
-            );
+            try {
+                Class<?> clazz = JvmTestExecutionSpec.class;
+                // This constructor is available in Gradle 6.4+
+                Constructor<?> constructor = clazz.getConstructor(
+                    TestFramework.class,
+                    Iterable.class,
+                    Iterable.class,
+                    FileTree.class,
+                    boolean.class,
+                    FileCollection.class,
+                    String.class,
+                    org.gradle.util.Path.class,
+                    long.class,
+                    JavaForkOptions.class,
+                    int.class,
+                    Set.class
+                );
+
+                return (JvmTestExecutionSpec) constructor.newInstance(
+                    testFramework,
+                    source.getClasspath(),
+                    source.getModulePath(),
+                    source.getCandidateClassFiles(),
+                    source.isScanForTestClasses(),
+                    source.getTestClassesDirs(),
+                    source.getPath(),
+                    source.getIdentityPath(),
+                    source.getForkEvery(),
+                    source.getJavaForkOptions(),
+                    source.getMaxParallelForks(),
+                    source.getPreviousFailedTestClasses()
+                );
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
         }
     },
 
     FACTORY_FOR_GRADLE_OLDER_THAN_V6_4 {
         @Override
         JvmTestExecutionSpec createExecutionSpec(TestFramework testFramework, JvmTestExecutionSpec source) {
-            // This constructor is in Gradle 4.7+
-            return new JvmTestExecutionSpec(
-                testFramework,
-                source.getClasspath(),
-                source.getCandidateClassFiles(),
-                source.isScanForTestClasses(),
-                source.getTestClassesDirs(),
-                source.getPath(),
-                source.getIdentityPath(),
-                source.getForkEvery(),
-                source.getJavaForkOptions(),
-                source.getMaxParallelForks(),
-                source.getPreviousFailedTestClasses()
-            );
+            try {
+                Class<?> clazz = JvmTestExecutionSpec.class;
+                // This constructor is available in Gradle 4.7+
+                Constructor<?> constructor = clazz.getConstructor(
+                    TestFramework.class,
+                    Iterable.class,
+                    FileTree.class,
+                    boolean.class,
+                    FileCollection.class,
+                    String.class,
+                    org.gradle.util.Path.class,
+                    long.class,
+                    JavaForkOptions.class,
+                    int.class,
+                    Set.class
+                );
+
+                return (JvmTestExecutionSpec) constructor.newInstance(
+                    testFramework,
+                    source.getClasspath(),
+                    source.getCandidateClassFiles(),
+                    source.isScanForTestClasses(),
+                    source.getTestClassesDirs(),
+                    source.getPath(),
+                    source.getIdentityPath(),
+                    source.getForkEvery(),
+                    source.getJavaForkOptions(),
+                    source.getMaxParallelForks(),
+                    source.getPreviousFailedTestClasses()
+                );
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
 
         }
     };

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/JvmTestExecutionSpecFactory.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/JvmTestExecutionSpecFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry.internal.executer;
+
+import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
+import org.gradle.api.internal.tasks.testing.TestFramework;
+import org.gradle.util.GradleVersion;
+
+enum JvmTestExecutionSpecFactory {
+
+    FACTORY_FOR_CURRENT_GRADLE_VERSION {
+        @Override
+        JvmTestExecutionSpec createExecutionSpec(TestFramework testFramework, JvmTestExecutionSpec source) {
+            return source.copyWithTestFramework(testFramework);
+        }
+    },
+
+    FACTORY_FOR_GRADLE_OLDER_THAN_V8 {
+        @Override
+        JvmTestExecutionSpec createExecutionSpec(TestFramework testFramework, JvmTestExecutionSpec source) {
+            // This constructor is in Gradle 6.4+
+            return new JvmTestExecutionSpec(
+                testFramework,
+                source.getClasspath(),
+                source.getModulePath(),
+                source.getCandidateClassFiles(),
+                source.isScanForTestClasses(),
+                source.getTestClassesDirs(),
+                source.getPath(),
+                source.getIdentityPath(),
+                source.getForkEvery(),
+                source.getJavaForkOptions(),
+                source.getMaxParallelForks(),
+                source.getPreviousFailedTestClasses()
+            );
+        }
+    },
+
+    FACTORY_FOR_GRADLE_OLDER_THAN_V6_4 {
+        @Override
+        JvmTestExecutionSpec createExecutionSpec(TestFramework testFramework, JvmTestExecutionSpec source) {
+            // This constructor is in Gradle 4.7+
+            return new JvmTestExecutionSpec(
+                testFramework,
+                source.getClasspath(),
+                source.getCandidateClassFiles(),
+                source.isScanForTestClasses(),
+                source.getTestClassesDirs(),
+                source.getPath(),
+                source.getIdentityPath(),
+                source.getForkEvery(),
+                source.getJavaForkOptions(),
+                source.getMaxParallelForks(),
+                source.getPreviousFailedTestClasses()
+            );
+
+        }
+    };
+
+    abstract JvmTestExecutionSpec createExecutionSpec(TestFramework testFramework, JvmTestExecutionSpec source);
+
+    static JvmTestExecutionSpec testExecutionSpecFor(TestFramework testFramework, JvmTestExecutionSpec source) {
+        JvmTestExecutionSpecFactory factory = getInstance();
+        return factory.createExecutionSpec(testFramework, source);
+    }
+
+    private static JvmTestExecutionSpecFactory getInstance() {
+        if (gradleVersionIsAtLeast("8.0")) {
+            return FACTORY_FOR_CURRENT_GRADLE_VERSION;
+        } else if (gradleVersionIsAtLeast("6.4")) {
+            return FACTORY_FOR_GRADLE_OLDER_THAN_V8;
+        } else {
+            return FACTORY_FOR_GRADLE_OLDER_THAN_V6_4;
+        }
+    }
+
+    private static boolean gradleVersionIsAtLeast(String version) {
+        return GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version(version)) >= 0;
+    }
+
+}

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -33,7 +33,7 @@ import java.io.File;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.gradle.testretry.internal.executer.framework.TestFrameworkStrategy.gradleVersionIsAtLeast;
+import static org.gradle.testretry.internal.executer.JvmTestExecutionSpecFactory.testExecutionSpecFor;
 
 public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
 
@@ -121,7 +121,7 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
                 break;
             } else {
                 TestFramework retryTestFramework = testFrameworkStrategy.createRetrying(frameworkTemplate, spec.getTestFramework(), result.failedTests);
-                testExecutionSpec = createRetryJvmExecutionSpec(spec, retryTestFramework);
+                testExecutionSpec = testExecutionSpecFor(retryTestFramework, spec);
                 retryTestResultProcessor.reset(++retryCount == maxRetries);
             }
         }
@@ -138,41 +138,6 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
 
     private boolean hasNonRetriedTests() {
         return lastResult != null && !lastResult.nonRetriedTests.isEmpty();
-    }
-
-    private JvmTestExecutionSpec createRetryJvmExecutionSpec(JvmTestExecutionSpec spec, TestFramework retryTestFramework) {
-        if (gradleVersionIsAtLeast("6.4")) {
-            // This constructor is in Gradle 6.4+
-            return new JvmTestExecutionSpec(
-                retryTestFramework,
-                spec.getClasspath(),
-                spec.getModulePath(),
-                spec.getCandidateClassFiles(),
-                spec.isScanForTestClasses(),
-                spec.getTestClassesDirs(),
-                spec.getPath(),
-                spec.getIdentityPath(),
-                spec.getForkEvery(),
-                spec.getJavaForkOptions(),
-                spec.getMaxParallelForks(),
-                spec.getPreviousFailedTestClasses()
-            );
-        } else {
-            // This constructor is in Gradle 4.7+
-            return new JvmTestExecutionSpec(
-                retryTestFramework,
-                spec.getClasspath(),
-                spec.getCandidateClassFiles(),
-                spec.isScanForTestClasses(),
-                spec.getTestClassesDirs(),
-                spec.getPath(),
-                spec.getIdentityPath(),
-                spec.getForkEvery(),
-                spec.getJavaForkOptions(),
-                spec.getMaxParallelForks(),
-                spec.getPreviousFailedTestClasses()
-            );
-        }
     }
 
     @Override


### PR DESCRIPTION
This PR uses the new `copyWithTestFramework` method when creating a new `JvmTestExecutionSpec` in the test retry executer.

This ensures that we do not have to adapt again, if the execution spec gets changed again in the future.

The constructor for older Gradle versions is called via reflection. Therefore, [constructors for older test-retry versions](https://github.com/gradle/gradle/blob/master/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java#L45-L54) can be removed from the Gradle 8 code base.
