### PR TITLE
Provide better error message if `retry` extension is already present

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -82,7 +82,7 @@ public final class TestTaskConfigurer {
                 throw new IllegalStateException(""
                     + "Another plugin is conflicting with the Test Retry Gradle plugin "
                     + "and has already added a retry extension to the test task " + testTask.getName() + ". "
-                    + "Please either remove the conflicting plugin or the Test Retry Gradle plugin from this test task."
+                    + "Please either remove the conflicting plugin or the Test Retry Gradle plugin from this test project."
                 );
             }
         }

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -75,7 +75,7 @@ public final class TestTaskConfigurer {
                     + "The Gradle Enterprise Gradle plugin is conflicting with the Test Retry Gradle plugin "
                     + "and has already added a retry extension to the test task " + testTask.getName() + ". "
                     + "Please either remove the Test Retry Gradle plugin from this project "
-                    + "or disable the application of the retry extension in the Gradle Enterprise Gradle plugin "
+                    + "or disable the registration of the retry extension in the Gradle Enterprise Gradle plugin "
                     + "by specifying the system property 'gradle.enterprise.testretry.disabled'."
                 );
             } else {

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -38,11 +38,14 @@ public final class TestTaskConfigurer {
 
     private final static GradleVersion GRADLE_5_1 = GradleVersion.version("5.1");
     private final static GradleVersion GRADLE_6_1 = GradleVersion.version("6.1");
+    private final static String GRADLE_ENTERPRISE_BASE_PACKAGE = "com.gradle.enterprise";
 
     private TestTaskConfigurer() {
     }
 
     public static void configureTestTask(Test test, ObjectFactory objectFactory, ProviderFactory providerFactory) {
+        ensureThatNoRetryExtensionIsPresent(test);
+
         GradleVersion gradleVersion = GradleVersion.current();
 
         TestRetryTaskExtension extension = objectFactory.newInstance(DefaultTestRetryTaskExtension.class);
@@ -59,6 +62,30 @@ public final class TestTaskConfigurer {
 
         test.doFirst(new ConditionalTaskAction(isDeactivatedByTestDistributionPlugin, new InitTaskAction(adapter, objectFactory)));
         test.doLast(new ConditionalTaskAction(isDeactivatedByTestDistributionPlugin, new FinalizeTaskAction()));
+    }
+
+    private static void ensureThatNoRetryExtensionIsPresent(Test testTask) {
+        Object existingRetryExtension = testTask.getExtensions().findByName(TestRetryTaskExtension.NAME);
+
+        if (existingRetryExtension != null) {
+            String retryExtensionClassName = existingRetryExtension.getClass().getName();
+
+            if (retryExtensionClassName.startsWith(GRADLE_ENTERPRISE_BASE_PACKAGE)) {
+                throw new IllegalStateException(""
+                    + "The Gradle Enterprise Gradle plugin is conflicting with the Test Retry Gradle plugin "
+                    + "and has already added a retry extension to the test task " + testTask.getName() + ". "
+                    + "Please either remove the Test Retry Gradle plugin from this test task "
+                    + "or disable the application of the retry extension in the Gradle Enterprise Gradle plugin "
+                    + "by specifying the system property 'gradle.enterprise.testretry.disabled'."
+                );
+            } else {
+                throw new IllegalStateException(""
+                    + "Another plugin is conflicting with the Test Retry Gradle plugin "
+                    + "and has already added a retry extension to the test task " + testTask.getName() + ". "
+                    + "Please either remove the conflicting plugin or the Test Retry Gradle plugin from this test task."
+                );
+            }
+        }
     }
 
     private static Provider<Boolean> shouldTestRetryPluginBeDeactivated(

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -74,7 +74,7 @@ public final class TestTaskConfigurer {
                 throw new IllegalStateException(""
                     + "The Gradle Enterprise Gradle plugin is conflicting with the Test Retry Gradle plugin "
                     + "and has already added a retry extension to the test task " + testTask.getName() + ". "
-                    + "Please either remove the Test Retry Gradle plugin from this test task "
+                    + "Please either remove the Test Retry Gradle plugin from this project "
                     + "or disable the application of the retry extension in the Gradle Enterprise Gradle plugin "
                     + "by specifying the system property 'gradle.enterprise.testretry.disabled'."
                 );

--- a/plugin/src/test/groovy/org/gradle/testretry/AbstractPluginFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/AbstractPluginFuncTest.groovy
@@ -115,6 +115,10 @@ abstract class AbstractPluginFuncTest extends Specification {
         baseBuildScript() - "id 'org.gradle.test-retry'"
     }
 
+    String baseBuildScriptWithNotAppliedTestRetryPlugin() {
+        baseBuildScript().replace("id 'org.gradle.test-retry'", "id 'org.gradle.test-retry' apply false")
+    }
+
     String testLanguage() {
         'java'
     }

--- a/plugin/src/test/groovy/org/gradle/testretry/CollidingRetryExtensionPluginFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/CollidingRetryExtensionPluginFuncTest.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry
+
+class CollidingRetryExtensionPluginFuncTest extends AbstractGeneralPluginFuncTest {
+
+    def "detects existing retry extension from Gradle Enterprise Gradle plugin"() {
+        given:
+        buildSrcWithEmptyClass("com.gradle.enterprise.testretry", "TestRetryExtension")
+
+        and:
+        buildFile.text = baseBuildScriptWithNotAppliedTestRetryPlugin()
+        applySomePluginWhichAddsRetryExtensionForClass("com.gradle.enterprise.testretry.TestRetryExtension")
+        applyTestRetryPlugin()
+
+        when:
+        def result = gradleRunner(gradleVersion).buildAndFail()
+
+        then:
+        result.output.contains("The Gradle Enterprise Gradle plugin is conflicting with the Test Retry Gradle plugin")
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+
+    def "detects existing retry extension from some other Gradle plugin"() {
+        given:
+        buildFile.text = baseBuildScriptWithNotAppliedTestRetryPlugin()
+        applySomePluginWhichAddsRetryExtensionForClass("java.lang.Object")
+        applyTestRetryPlugin()
+
+        when:
+        def result = gradleRunner(gradleVersion).buildAndFail()
+
+        then:
+        result.output.contains("Another plugin is conflicting with the Test Retry Gradle plugin")
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+
+    void buildSrcWithEmptyClass(String packageName, String className) {
+        def buildSrc = new FileTreeBuilder(testProjectDir.newFolder("buildSrc"))
+
+        buildSrc {
+            file("build.gradle")
+            dir("src/main/java") {
+                dir(packageName.replace('.', '/')) {
+                    file("${className}.java") {
+                        text = """
+                            package ${packageName};
+                            public class ${className} {
+                            }
+                        """.stripMargin()
+                    }
+                }
+            }
+
+        }
+    }
+
+    void applyTestRetryPlugin() {
+        buildFile << """
+            apply plugin: "org.gradle.test-retry"
+        """
+    }
+
+    void applySomePluginWhichAddsRetryExtensionForClass(String extensionClassName) {
+        buildFile << """
+            class SomePlugin implements Plugin<Project> {
+                void apply(Project target) {
+                    target.tasks.withType(Test).configureEach {
+                        extensions.add("retry", new ${extensionClassName}())
+                    }
+                }
+            }
+
+            apply plugin: SomePlugin
+        """
+
+    }
+}


### PR DESCRIPTION
Before registering the `retry` extension, the Test Retry Gradle plugin now checks for the presence of `retry` extension.

* If there already one registered, it will provide a proper error message.
* In case the extension uses the `com.gradle.enterprise` package, it is assumed, that the Gradle Enterprise Gradle plugin has added it. In this case, the error message includes a way how to disable the retry application by the Gradle Enterprise Gradle plugin
