### PR TITLE
Adjust to system property from Gradle Enterprise when `retry` extensions collide

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -76,7 +76,7 @@ public final class TestTaskConfigurer {
                     + "and has already added a retry extension to the test task " + testTask.getName() + ". "
                     + "Please either remove the Test Retry Gradle plugin from this project "
                     + "or disable the registration of the retry extension in the Gradle Enterprise Gradle plugin "
-                    + "by specifying the system property 'gradle.enterprise.testretry.enabled' and set it to 'true'."
+                    + "by specifying the system property 'gradle.enterprise.testretry.enabled' and set it to 'false'."
                 );
             } else {
                 throw new IllegalStateException(""

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -76,7 +76,7 @@ public final class TestTaskConfigurer {
                     + "and has already added a retry extension to the test task " + testTask.getName() + ". "
                     + "Please either remove the Test Retry Gradle plugin from this project "
                     + "or disable the registration of the retry extension in the Gradle Enterprise Gradle plugin "
-                    + "by specifying the system property 'gradle.enterprise.testretry.disabled'."
+                    + "by specifying the system property 'gradle.enterprise.testretry.enabled' and set it to 'true'."
                 );
             } else {
                 throw new IllegalStateException(""

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -76,7 +76,7 @@ public final class TestTaskConfigurer {
                     + "and has already added a retry extension to the test task " + testTask.getName() + ". "
                     + "Please either remove the Test Retry Gradle plugin from this project "
                     + "or disable the registration of the retry extension in the Gradle Enterprise Gradle plugin "
-                    + "by specifying the system property 'gradle.enterprise.testretry.enabled' and set it to 'false'."
+                    + "by specifying the system property 'gradle.enterprise.testretry.enabled' and setting it to 'false'."
                 );
             } else {
                 throw new IllegalStateException(""


### PR DESCRIPTION
When the Test Retry Gradle plugin detects an existing `retry` extension and concludes, that this must come from the Gradle Enterprise Gradle plugin, it now uses the adjusted system property to fix the problem.


Verify all build: https://builds.gradle.org/buildConfiguration/GradlePlugins_GradleTestRetryPlugin_null_VerifyAll/58819752?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true