### PR TITLE
Update Gradle wrapper to nightly version of 2022-12-05

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.0-20221130035948+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.0-20221205131849+0000-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This nightly version no longer has constructors for things we should not call in the test retry plugin.

See https://github.com/gradle/gradle/pull/22912

Verify all build [here](https://builds.gradle.org/buildConfiguration/GradlePlugins_GradleTestRetryPlugin_null_VerifyAll/59100382?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true)