### PR TITLE
Add a daily build against Gradle nightly for Test Retry plugin

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,8 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO reenable java https://github.com/gradle/ge/issues/20203
-        language: [ ]
+        language: [ 'java' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
@@ -43,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java' ]
+        # TODO reenable java https://github.com/gradle/ge/issues/20203
+        language: [ ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -129,7 +129,7 @@ project {
 //            triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 16
-                minute = 02
+                minute = 3
             }
 //            branchFilter = "+:<default>"
 //            branchFilter = "+:refs/head/jgauthier/20027"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -129,9 +129,9 @@ project {
 //            triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 16
-                minute = 28
+                minute = 41
             }
-//            branchFilter = "+:<default>"
+            branchFilter = "+:<default>"
 //            branchFilter = "+:jgauthier/20027"
 //            buildParams {
 //                this.add(Parameter(triggerPropertyName, "SCHEDULED-TRIGGER"))

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -129,7 +129,7 @@ project {
             triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 15
-                minute = 56
+                minute = 57
             }
 //            branchFilter = "+:<default>"
             branchFilter = "+:refs/head/jgauthier/20027"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -129,7 +129,7 @@ project {
             triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 15
-                minute = 24
+                minute = 31
             }
 //            branchFilter = "+:<default>"
             branchFilter = "+:refs/head/jgauthier/20027"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -129,7 +129,7 @@ project {
             triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 15
-                minute = 31
+                minute = 32
             }
 //            branchFilter = "+:<default>"
             branchFilter = "+:refs/head/jgauthier/20027"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -119,7 +119,8 @@ project {
         }
         triggers.schedule {
             schedulingPolicy = daily {
-                hour = 2
+                hour = 14
+                minute = 27
             }
             branchFilter = "+:<default>"
             triggerBuild = always()

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -31,7 +31,7 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 'Debug' option is available in the context menu for the task.
 */
 
-version = "2021.1"
+version = "2022.10"
 
 project {
     params {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -129,7 +129,7 @@ project {
             triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 15
-                minute = 47
+                minute = 56
             }
 //            branchFilter = "+:<default>"
             branchFilter = "+:refs/head/jgauthier/20027"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -129,7 +129,7 @@ project {
 //            triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 16
-                minute = 3
+                minute = 4
             }
 //            branchFilter = "+:<default>"
 //            branchFilter = "+:refs/head/jgauthier/20027"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -122,14 +122,14 @@ project {
             gradle {
                 tasks = "clean nightlyWrapper assemble"
                 buildFile = ""
-                gradleParams = "-s $useGradleInternalScansServer $buildCacheSetup"
+                gradleParams = "--daemon" //-s $useGradleInternalScansServer $buildCacheSetup"
             }
         }
         triggers.schedule {
             triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 15
-                minute = 10
+                minute = 24
             }
 //            branchFilter = "+:<default>"
             branchFilter = "+:refs/head/jgauthier/20027"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -128,7 +128,7 @@ project {
             triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 14
-                minute = 48
+                minute = 50
             }
 //            branchFilter = "+:<default>"
             branchFilter = "+:refs/head/jgauthier/20027"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -120,7 +120,7 @@ project {
     val gradleNightlyDogfoodingBuildType = buildType("Gradle Nightly dogfooding (nightly)") {
         steps {
             gradle {
-                tasks = "nightlyWrapper assemble"
+                tasks = "clean nightlyWrapper assemble"
                 buildFile = ""
                 gradleParams = "-s $useGradleInternalScansServer $buildCacheSetup"
             }
@@ -128,8 +128,8 @@ project {
         triggers.schedule {
             triggerRules = projectTriggerRules
             schedulingPolicy = daily {
-                hour = 14
-                minute = 54
+                hour = 15
+                minute = 10
             }
 //            branchFilter = "+:<default>"
             branchFilter = "+:refs/head/jgauthier/20027"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -115,6 +115,7 @@ project {
         -:.teamcity/**
         -:.github/**
     """.trimIndent()
+    val triggerPropertyName = "build.trigger.type"
 
     val gradleNightlyDogfoodingBuildType = buildType("Gradle Nightly dogfooding (nightly)") {
         steps {
@@ -128,12 +129,16 @@ project {
             triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 14
-                minute = 50
+                minute = 54
             }
 //            branchFilter = "+:<default>"
             branchFilter = "+:refs/head/jgauthier/20027"
-            triggerBuild = always()
+            buildParams {
+                this.add(Parameter(triggerPropertyName, "SCHEDULED-TRIGGER"))
+                this.add(Parameter(triggerPropertyName, "NIGHTLY-TRIGGER"))
+            }
             withPendingChangesOnly = false
+            triggerBuild = always()
         }
     }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -120,9 +120,10 @@ project {
         triggers.schedule {
             schedulingPolicy = daily {
                 hour = 14
-                minute = 27
+                minute = 30
             }
-            branchFilter = "+:<default>"
+//            branchFilter = "+:<default>"
+            branchFilter = "+:refs/head/jgauthier/20027"
             triggerBuild = always()
             withPendingChangesOnly = false
         }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -87,7 +87,7 @@ project {
             schedulingPolicy = daily {
                 hour = 2
             }
-            branchFilter = "+:refs/head/main"
+            branchFilter = "+:main"
             triggerBuild = always()
             withPendingChangesOnly = false
         }
@@ -109,14 +109,6 @@ project {
             }
         }
     }
-    val projectTriggerRules = """
-        -:docs/**
-        -:samples/**
-        -:.teamcity/**
-        -:.github/**
-    """.trimIndent()
-    val triggerPropertyName = "build.trigger.type"
-
     val gradleNightlyDogfoodingBuildType = buildType("Gradle Nightly dogfooding (nightly)") {
         steps {
             gradle {
@@ -126,17 +118,11 @@ project {
             }
         }
         triggers.schedule {
-//            triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 16
-                minute = 41
+                minute = 50
             }
-            branchFilter = "+:<default>"
-//            branchFilter = "+:jgauthier/20027"
-//            buildParams {
-//                this.add(Parameter(triggerPropertyName, "SCHEDULED-TRIGGER"))
-//                this.add(Parameter(triggerPropertyName, "NIGHTLY-TRIGGER"))
-//            }
+            branchFilter = "+:refs/heads/jgauthier/20027"
             withPendingChangesOnly = false
             triggerBuild = always()
         }
@@ -172,7 +158,7 @@ project {
                 schedulingPolicy = daily {
                     hour = 2
                 }
-                branchFilter = "+:refs/head/main"
+                branchFilter = "+:main"
                 triggerBuild = always()
                 withPendingChangesOnly = false
             }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -109,6 +109,13 @@ project {
             }
         }
     }
+    val projectTriggerRules = """
+        -:docs/**
+        -:samples/**
+        -:.teamcity/**
+        -:.github/**
+    """.trimIndent()
+
     val gradleNightlyDogfoodingBuildType = buildType("Gradle Nightly dogfooding (nightly)") {
         steps {
             gradle {
@@ -118,9 +125,10 @@ project {
             }
         }
         triggers.schedule {
+            triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 14
-                minute = 30
+                minute = 48
             }
 //            branchFilter = "+:<default>"
             branchFilter = "+:refs/head/jgauthier/20027"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -129,7 +129,7 @@ project {
             triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 15
-                minute = 32
+                minute = 47
             }
 //            branchFilter = "+:<default>"
             branchFilter = "+:refs/head/jgauthier/20027"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -31,7 +31,7 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 'Debug' option is available in the context menu for the task.
 */
 
-version = "2022.10"
+version = "2021.1"
 
 project {
     params {
@@ -107,6 +107,23 @@ project {
                 onDependencyFailure = FailureAction.CANCEL
                 onDependencyCancel = FailureAction.CANCEL
             }
+        }
+    }
+    val gradleNightlyDogfoodingBuildType = buildType("Gradle Nightly dogfooding (nightly)") {
+        steps {
+            gradle {
+                tasks = "nightlyWrapper assemble"
+                buildFile = ""
+                gradleParams = "-s $useGradleInternalScansServer $buildCacheSetup"
+            }
+        }
+        triggers.schedule {
+            schedulingPolicy = daily {
+                hour = 2
+            }
+            branchFilter = "+:<default>"
+            triggerBuild = always()
+            withPendingChangesOnly = false
         }
     }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -122,23 +122,23 @@ project {
             gradle {
                 tasks = "clean nightlyWrapper assemble"
                 buildFile = ""
-                gradleParams = "--daemon" //-s $useGradleInternalScansServer $buildCacheSetup"
+                gradleParams = "-s $useGradleInternalScansServer $buildCacheSetup"
             }
         }
         triggers.schedule {
 //            triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 16
-                minute = 19
+                minute = 28
             }
 //            branchFilter = "+:<default>"
-            branchFilter = "+:jgauthier/20027"
+//            branchFilter = "+:jgauthier/20027"
 //            buildParams {
 //                this.add(Parameter(triggerPropertyName, "SCHEDULED-TRIGGER"))
 //                this.add(Parameter(triggerPropertyName, "NIGHTLY-TRIGGER"))
 //            }
             withPendingChangesOnly = false
-//            triggerBuild = always()
+            triggerBuild = always()
         }
     }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -129,7 +129,7 @@ project {
 //            triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 16
-                minute = 4
+                minute = 11
             }
 //            branchFilter = "+:<default>"
 //            branchFilter = "+:refs/head/jgauthier/20027"
@@ -137,7 +137,7 @@ project {
 //                this.add(Parameter(triggerPropertyName, "SCHEDULED-TRIGGER"))
 //                this.add(Parameter(triggerPropertyName, "NIGHTLY-TRIGGER"))
 //            }
-//            withPendingChangesOnly = false
+            withPendingChangesOnly = false
 //            triggerBuild = always()
         }
     }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -129,10 +129,10 @@ project {
 //            triggerRules = projectTriggerRules
             schedulingPolicy = daily {
                 hour = 16
-                minute = 11
+                minute = 19
             }
 //            branchFilter = "+:<default>"
-//            branchFilter = "+:refs/head/jgauthier/20027"
+            branchFilter = "+:jgauthier/20027"
 //            buildParams {
 //                this.add(Parameter(triggerPropertyName, "SCHEDULED-TRIGGER"))
 //                this.add(Parameter(triggerPropertyName, "NIGHTLY-TRIGGER"))

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -87,7 +87,7 @@ project {
             schedulingPolicy = daily {
                 hour = 2
             }
-            branchFilter = "+:main"
+            branchFilter = "+:refs/heads/main"
             triggerBuild = always()
             withPendingChangesOnly = false
         }
@@ -119,10 +119,9 @@ project {
         }
         triggers.schedule {
             schedulingPolicy = daily {
-                hour = 16
-                minute = 50
+                hour = 2
             }
-            branchFilter = "+:refs/heads/jgauthier/20027"
+            branchFilter = "+:refs/heads/main"
             withPendingChangesOnly = false
             triggerBuild = always()
         }
@@ -158,7 +157,7 @@ project {
                 schedulingPolicy = daily {
                     hour = 2
                 }
-                branchFilter = "+:main"
+                branchFilter = "+:refs/heads/main"
                 triggerBuild = always()
                 withPendingChangesOnly = false
             }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -126,19 +126,19 @@ project {
             }
         }
         triggers.schedule {
-            triggerRules = projectTriggerRules
+//            triggerRules = projectTriggerRules
             schedulingPolicy = daily {
-                hour = 15
-                minute = 57
+                hour = 16
+                minute = 02
             }
 //            branchFilter = "+:<default>"
-            branchFilter = "+:refs/head/jgauthier/20027"
-            buildParams {
-                this.add(Parameter(triggerPropertyName, "SCHEDULED-TRIGGER"))
-                this.add(Parameter(triggerPropertyName, "NIGHTLY-TRIGGER"))
-            }
-            withPendingChangesOnly = false
-            triggerBuild = always()
+//            branchFilter = "+:refs/head/jgauthier/20027"
+//            buildParams {
+//                this.add(Parameter(triggerPropertyName, "SCHEDULED-TRIGGER"))
+//                this.add(Parameter(triggerPropertyName, "NIGHTLY-TRIGGER"))
+//            }
+//            withPendingChangesOnly = false
+//            triggerBuild = always()
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("nebula.release") version "15.3.1"
-    id("gradlebuild.wrapper")
 }
 
 buildScan {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("nebula.release") version "15.3.1"
+    id("gradlebuild.wrapper")
 }
 
 buildScan {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,3 +32,12 @@ tasks.named("final") {
 tasks.named("candidate") {
     dependsOn(publishPlugins)
 }
+
+tasks.register<Wrapper>("nightlyWrapper") {
+    group = "wrapper"
+    doFirst {
+        val jsonText = java.net.URL("https://services.gradle.org/versions/$label").readText()
+        val versionInfo = Gson().fromJson(jsonText, VersionDownloadInfo::class.java)
+        distributionUrl = versionInfo.downloadUrl
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,12 +31,3 @@ tasks.named("final") {
 tasks.named("candidate") {
     dependsOn(publishPlugins)
 }
-
-tasks.register<Wrapper>("nightlyWrapper") {
-    group = "wrapper"
-    doFirst {
-        val jsonText = java.net.URL("https://services.gradle.org/versions/$label").readText()
-        val versionInfo = Gson().fromJson(jsonText, VersionDownloadInfo::class.java)
-        distributionUrl = versionInfo.downloadUrl
-    }
-}

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -204,6 +204,7 @@ tasks.register<Wrapper>("nightlyWrapper") {
     doFirst {
         val jsonText = URL("https://services.gradle.org/versions/nightly").readText()
         val versionInfo = Gson().fromJson(jsonText, VersionDownloadInfo::class.java)
-        distributionUrl = versionInfo.downloadUrl
+//        distributionUrl = versionInfo.downloadUrl
+        distributionUrl = "https://services.gradle.org/distributions/gradle-8.0-rc-2-bin.zip"
     }
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -2,6 +2,8 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.testretry.build.GradleVersionData
 import org.gradle.testretry.build.GradleVersionsCommandLineArgumentProvider
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import com.google.gson.Gson
+import java.net.URL
 
 plugins {
     java
@@ -193,4 +195,15 @@ tasks.register<Test>("testGradleReleases") {
 
 tasks.register<Test>("testGradleNightlies") {
     jvmArgumentProviders.add(GradleVersionsCommandLineArgumentProvider(GradleVersionData::getNightlyVersions))
+}
+
+private data class VersionDownloadInfo(val version: String, val downloadUrl: String)
+
+tasks.register<Wrapper>("nightlyWrapper") {
+    group = "wrapper"
+    doFirst {
+        val jsonText = URL("https://services.gradle.org/versions/nightly").readText()
+        val versionInfo = Gson().fromJson(jsonText, VersionDownloadInfo::class.java)
+        distributionUrl = versionInfo.downloadUrl
+    }
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -204,7 +204,6 @@ tasks.register<Wrapper>("nightlyWrapper") {
     doFirst {
         val jsonText = URL("https://services.gradle.org/versions/nightly").readText()
         val versionInfo = Gson().fromJson(jsonText, VersionDownloadInfo::class.java)
-//        distributionUrl = versionInfo.downloadUrl
-        distributionUrl = "https://services.gradle.org/distributions/gradle-8.0-rc-2-bin.zip"
+        distributionUrl = versionInfo.downloadUrl
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,9 @@
+buildscript {
+    dependencies {
+        classpath("com.google.code.gson:gson:2.10.1")
+    }
+}
+
 plugins {
     id("com.gradle.enterprise").version("3.10")
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.7.6")


### PR DESCRIPTION
- Adds a `nightlyWrapper` task
- Adds a daily build against Gradle nightly
- Fixes the branch filters that prevented the trigger schedules from firing (I'm not entirely sure the `refs/heads` prefix is needed for `main`, I couldn't test it on my branch)
- Updates the Github Action versions for CodeQL