### PR TITLE
Use snapshot task when publishing nightly to internal Artifactory

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -138,7 +138,7 @@ project {
 
             steps {
                 gradle {
-                    tasks = "clean devSnapshot publishPluginPublicationToGradleBuildInternalSnapshotsRepository -x test"
+                    tasks = "clean snapshot publishPluginPublicationToGradleBuildInternalSnapshotsRepository -x test"
                     gradleParams =
                         "-s $useGradleInternalScansServer $buildCacheSetup $useGradleInternalScansServer"
                     param("org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration", "GLOBAL")


### PR DESCRIPTION
Using the `devSnapshot` task provided by the [Nebula release plugin](https://github.com/nebula-plugins/nebula-release-plugin) creates an artifact version of the form `<major>.<minor>.<patch>-dev.#+<hash>`.

A subsequent nightly job w/o a new commit therefore leads to the same version number. Our internal Artifactory refuses to overwrite the uploaded JAR.

Using the `snapshot` task create an artifact version of the form `<major>.<minor>.<patch>-SNAPSHOT`. We assume, that the internal Artifactory allows overwriting an artifact with "-SNAPSHOT" ending.
