### PR TITLE
Handle flaky setup that fails after success and prevents failed methods from being re-tried

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -138,7 +138,7 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
 
     public void failWithNonRetriedTestsIfAny() {
         if (extension.getSimulateNotRetryableTest() || hasNonRetriedTests()) {
-            throw new IllegalStateException("org.gradle.test-retry was unable to retry the following test methods, which is unexpected. Please file a bug report at https://github.com/gradle/test-retry-gradle-plugin/issues" +
+            throw new IllegalStateException("The following test methods could not be retried, which is unexpected. Please file a bug report at https://github.com/gradle/test-retry-gradle-plugin/issues" +
                 lastResult.nonRetriedTests.stream()
                     .flatMap(entry -> entry.getValue().stream().map(methodName -> "   " + entry.getKey() + "#" + methodName))
                     .collect(Collectors.joining("\n", "\n", "\n")));

--- a/plugin/src/test/groovy/org/gradle/testretry/AbstractPluginFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/AbstractPluginFuncTest.groovy
@@ -78,6 +78,24 @@ abstract class AbstractPluginFuncTest extends Specification {
                         throw new java.io.UncheckedIOException(e);
                     }
                 }
+
+                public static void flakyAssertPassFailPass(String id) {
+                    Path marker = Paths.get("build/marker.file." + id);
+                    try {
+                        if (Files.exists(marker)) {
+                            int counter = Integer.parseInt(new String(Files.readAllBytes(marker)));
+                            ++counter;
+                            Files.write(marker, Integer.toString(counter).getBytes());
+                            if (counter == 1) {
+                                throw new RuntimeException("fail me!");
+                            }
+                        } else {
+                            Files.write(marker, "0".getBytes());
+                        }
+                    } catch (java.io.IOException e) {
+                        throw new java.io.UncheckedIOException(e);
+                    }
+                }
             }
         """
     }
@@ -130,6 +148,10 @@ abstract class AbstractPluginFuncTest extends Specification {
 
     static String flakyAssert(String id = "id", int failures = 1) {
         return "acme.FlakyAssert.flakyAssert(\"${StringEscapeUtils.escapeJava(id)}\", $failures);"
+    }
+
+    static String flakyAssertPassFailPass(String id = "id") {
+        return "acme.FlakyAssert.flakyAssertPassFailPass(\"${StringEscapeUtils.escapeJava(id)}\");"
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4FuncTest.groovy
@@ -611,6 +611,10 @@ class JUnit4FuncTest extends AbstractFrameworkFuncTest {
                 public void flakyTest() {
                     ${flakyAssert("method")}
                 }
+
+                @org.junit.Test
+                public void successfulTest() {
+                }
             }
         """
 
@@ -623,6 +627,7 @@ class JUnit4FuncTest extends AbstractFrameworkFuncTest {
             it.count("${beforeClassErrorTestMethodName(gradleVersion)} FAILED") == 1
             it.count("${beforeClassErrorTestMethodName(gradleVersion)} PASSED") == 1
             it.count('flakyTest PASSED') == 1
+            it.count('successfulTest PASSED') == 2
         }
 
         where:

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4FuncTest.groovy
@@ -590,4 +590,42 @@ class JUnit4FuncTest extends AbstractFrameworkFuncTest {
         where:
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST
     }
+
+    def "handles flaky setup that prevents the retries of initially failed methods (gradle version #gradleVersion)"() {
+        given:
+        buildFile << """
+            test.retry.maxRetries = 2
+        """
+
+        and:
+        writeJavaTestSource """
+            package acme;
+
+            public class FlakySetupAndMethodTest {
+                @org.junit.BeforeClass
+                public static void setup() {
+                    ${flakyAssertPassFailPass("setup")}
+                }
+
+                @org.junit.Test
+                public void flakyTest() {
+                    ${flakyAssert("method")}
+                }
+            }
+        """
+
+        when:
+        def result = gradleRunner(gradleVersion).build()
+
+        then:
+        with(result.output) {
+            it.count('flakyTest FAILED') == 1
+            it.count("${beforeClassErrorTestMethodName(gradleVersion)} FAILED") == 1
+            it.count("${beforeClassErrorTestMethodName(gradleVersion)} PASSED") == 1
+            it.count('flakyTest PASSED') == 1
+        }
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
 }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
@@ -379,6 +379,10 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
                 public void flakyTest() {
                     ${flakyAssert("method")}
                 }
+
+                @org.junit.jupiter.api.Test
+                public void successfulTest() {
+                }
             }
         """
 
@@ -391,6 +395,7 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
             it.count("${beforeClassErrorTestMethodName(gradleVersion)} FAILED") == 1
             it.count("${beforeClassErrorTestMethodName(gradleVersion)} PASSED") == 1
             it.count('flakyTest() PASSED') == 1
+            it.count('successfulTest() PASSED') == 2
         }
 
         where:

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
@@ -359,6 +359,44 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST
     }
 
+    def "handles flaky setup that prevents the retries of initially failed methods (gradle version #gradleVersion)"() {
+        given:
+        buildFile << """
+            test.retry.maxRetries = 2
+        """
+
+        and:
+        writeJavaTestSource """
+            package acme;
+
+            public class FlakySetupAndMethodTest {
+                @org.junit.jupiter.api.BeforeAll
+                public static void setup() {
+                    ${flakyAssertPassFailPass("setup")}
+                }
+
+                @org.junit.jupiter.api.Test
+                public void flakyTest() {
+                    ${flakyAssert("method")}
+                }
+            }
+        """
+
+        when:
+        def result = gradleRunner(gradleVersion).build()
+
+        then:
+        with(result.output) {
+            it.count('flakyTest() FAILED') == 1
+            it.count("${beforeClassErrorTestMethodName(gradleVersion)} FAILED") == 1
+            it.count("${beforeClassErrorTestMethodName(gradleVersion)} PASSED") == 1
+            it.count('flakyTest() PASSED') == 1
+        }
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+
     String reportedTestName(String testName) {
         testName + "()"
     }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockFuncTest.groovy
@@ -999,6 +999,11 @@ class SpockFuncTest extends AbstractFrameworkFuncTest {
                     expect:
                     ${flakyAssert("method")}
                 }
+
+                def successfulTest() {
+                    expect:
+                    true
+                }
             }
         """
 
@@ -1011,6 +1016,7 @@ class SpockFuncTest extends AbstractFrameworkFuncTest {
             it.count("${beforeClassErrorTestMethodName(gradleVersion)} FAILED") == 1
             it.count("${beforeClassErrorTestMethodName(gradleVersion)} PASSED") == 1
             it.count('flakyTest PASSED') == 1
+            it.count('successfulTest PASSED') == 2
         }
 
         where:

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGFuncTest.groovy
@@ -60,7 +60,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
         with(result.output) {
             it.count('lifecycle FAILED') == 1
             it.count('lifecycle PASSED') == 1
-            !it.contains("org.gradle.test-retry was unable to retry")
+            !it.contains("The following test methods could not be retried")
         }
 
         where:
@@ -97,7 +97,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
         then:
         with(result.output) {
             it.contains('There were failing tests. See the report')
-            !it.contains('org.gradle.test-retry was unable to retry the following test methods')
+            !it.contains('The following test methods could not be retried')
         }
 
         where:


### PR DESCRIPTION
### Summary

In case of a setup that fails after successful execution, we won't see descriptors for methods from the previous run and will fail with `org.gradle.test-retry was unable to retry the following test methods, which is unexpected`. This PR solves this case by adding all failed methods from the previous run to be re-tried again.