### PR TITLE
Replace test class inheritence from a spec class with a common abstract spec class

### DIFF
--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock1FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock1FuncTest.groovy
@@ -15,42 +15,29 @@
  */
 package org.gradle.testretry.testframework
 
-abstract class SpockBaseJunit5FuncTest extends SpockBaseFuncTest {
-
+class Spock1FuncTest extends SpockBaseFuncTest {
     @Override
-    boolean isRerunsParameterizedMethods() {
-        false
+    String getLanguagePlugin() {
+        return 'groovy'
     }
 
-    @Override
+    boolean isRerunsParameterizedMethods() {
+        true
+    }
+
     boolean canTargetInheritedMethods(String gradleVersion) {
         true
     }
 
-    @Override
     protected String staticInitErrorTestMethodName(String gradleVersion) {
-        gradleVersion == "5.0" ? "classMethod" : "initializationError"
-    }
-
-    @Override
-    protected String beforeClassErrorTestMethodName(String gradleVersion) {
         "initializationError"
     }
 
-    @Override
-    protected String afterClassErrorTestMethodName(String gradleVersion) {
-        "executionError"
+    protected String beforeClassErrorTestMethodName(String gradleVersion) {
+        "classMethod"
     }
 
-    @Override
-    protected String buildConfiguration() {
-        return """
-            dependencies {
-                implementation 'org.spockframework:spock-core:2.3-groovy-3.0'
-            }
-            test {
-                useJUnitPlatform()
-            }
-        """
+    protected String afterClassErrorTestMethodName(String gradleVersion) {
+        "classMethod"
     }
 }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseFuncTest.groovy
@@ -20,31 +20,21 @@ import spock.lang.Issue
 
 import static org.junit.Assume.assumeTrue
 
-class SpockFuncTest extends AbstractFrameworkFuncTest {
+abstract class SpockBaseFuncTest extends AbstractFrameworkFuncTest {
     @Override
     String getLanguagePlugin() {
         return 'groovy'
     }
 
-    boolean isRerunsParameterizedMethods() {
-        true
-    }
+    abstract boolean isRerunsParameterizedMethods()
 
-    boolean canTargetInheritedMethods(String gradleVersion) {
-        true
-    }
+    abstract boolean canTargetInheritedMethods(String gradleVersion)
 
-    protected String staticInitErrorTestMethodName(String gradleVersion) {
-        "initializationError"
-    }
+    abstract protected String staticInitErrorTestMethodName(String gradleVersion)
 
-    protected String beforeClassErrorTestMethodName(String gradleVersion) {
-        "classMethod"
-    }
+    abstract protected String beforeClassErrorTestMethodName(String gradleVersion)
 
-    protected String afterClassErrorTestMethodName(String gradleVersion) {
-        "classMethod"
-    }
+    abstract protected String afterClassErrorTestMethodName(String gradleVersion)
 
     def "handles failure in #lifecycle (gradle version #gradleVersion)"() {
         given:


### PR DESCRIPTION
With the current setup, the IDE won't be able to recognize that methods of `SpockFuncTest` can also be executed in the context of e.g. `Spock2FuncTest`. This happens because `SpockFuncTest` is not an abstract class and it can't be made one, because its own tests won't run. I introduced a common abstract base spec that is now shared by all children specs. This setup supports executing tests in the context of any child spec via IDE.