### PR TITLE
Retry Spock2 parameterized methods independently of the class

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -78,7 +78,7 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
             return;
         }
 
-        TestFrameworkStrategy testFrameworkStrategy = TestFrameworkStrategy.of(spec.getTestFramework());
+        TestFrameworkStrategy testFrameworkStrategy = TestFrameworkStrategy.of(spec);
         if (testFrameworkStrategy == null) {
             LOGGER.warn("Test retry requested for task {} with unsupported test framework {} - failing tests will not be retried", spec.getIdentityPath(), spec.getTestFramework().getClass().getName());
             delegate.execute(spec, testResultProcessor);

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/Junit5TestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/Junit5TestFrameworkStrategy.java
@@ -30,9 +30,15 @@ import static org.gradle.testretry.internal.executer.framework.TestFrameworkStra
 
 final class Junit5TestFrameworkStrategy extends BaseJunitTestFrameworkStrategy {
 
+    private final boolean isSpock2Used;
+
+    public Junit5TestFrameworkStrategy(boolean isSpock2Used) {
+        this.isSpock2Used = isSpock2Used;
+    }
+
     @Override
     public TestFramework createRetrying(TestFrameworkTemplate template, TestFramework testFramework, TestNames failedTests) {
-        DefaultTestFilter failedTestsFilter = testFilterFor(failedTests, false, template);
+        DefaultTestFilter failedTestsFilter = testFilterFor(failedTests, isSpock2Used, template);
         return testFrameworkProvider(template, testFramework).testFrameworkFor(failedTestsFilter);
     }
 

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock2FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock2FuncTest.groovy
@@ -68,7 +68,7 @@ class Spock2FuncTest extends SpockBaseJunit5FuncTest {
                                 defaultName + " [suffix]"
                             }
                         } else {
-                            feature.name = feature.name + " [suffix]"
+                            feature.displayName += " [suffix]"
                         }
                     }
                 }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock2FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock2FuncTest.groovy
@@ -20,6 +20,11 @@ import org.gradle.util.GradleVersion
 class Spock2FuncTest extends SpockBaseJunit5FuncTest {
 
     @Override
+    boolean isRerunsParameterizedMethods() {
+        true
+    }
+
+    @Override
     boolean canTargetInheritedMethods(String gradleVersion) {
         GradleVersion.version(gradleVersion) >= GradleVersion.version("7.0")
     }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseJunit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseJunit5FuncTest.groovy
@@ -18,11 +18,6 @@ package org.gradle.testretry.testframework
 abstract class SpockBaseJunit5FuncTest extends SpockBaseFuncTest {
 
     @Override
-    boolean isRerunsParameterizedMethods() {
-        false
-    }
-
-    @Override
     boolean canTargetInheritedMethods(String gradleVersion) {
         true
     }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockViaJUnitVintageFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockViaJUnitVintageFuncTest.groovy
@@ -18,6 +18,11 @@ package org.gradle.testretry.testframework
 class SpockViaJUnitVintageFuncTest extends SpockBaseJunit5FuncTest {
 
     @Override
+    boolean isRerunsParameterizedMethods() {
+        false
+    }
+
+    @Override
     protected String beforeClassErrorTestMethodName(String gradleVersion) {
         gradleVersion == "5.0" ? "classMethod" : "initializationError"
     }


### PR DESCRIPTION
### Summary

Previously, if Spock tests were executed using Gradle's `JUnitPlatformTestFramework`, we would retry an entire class if one of its parameterized methods failed. This applied both to Spock 2 tests and Spock 1 tests run with JUnit Vintage  engine. However, parameterized tests cannot be retried independently only in the latter case.

This PR changes that and checks for `spock-core-2*` JAR on the classpath to differentiate between both cases. If the JAR is present, parameterized tests will be retried independently, otherwise, as an entire class.