### PR TITLE
Fix Gradle wrapper upgrade action

### DIFF
--- a/.github/workflows/wrapper-upgrade.yml
+++ b/.github/workflows/wrapper-upgrade.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           TOKEN: ${{ secrets.GH_BOT_GITHUB_TOKEN }}
         run: |
-          git config --global url."https://${TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://bot-githubaction:${TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef
         with:

--- a/.github/workflows/wrapper-upgrade.yml
+++ b/.github/workflows/wrapper-upgrade.yml
@@ -34,4 +34,5 @@ jobs:
         with:
           arguments: clean upgradeGradleWrapperAll --no-build-cache
         env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.GH_BOT_GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("nebula.release") version "17.2.2"
-    id("org.gradle.wrapper-upgrade") version "0.11.2"
+    id("org.gradle.wrapper-upgrade") version "0.11.3"
 }
 
 buildScan {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ wrapperUpgrade {
     gradle {
         register("self") {
             repo.set("gradle/test-retry-gradle-plugin")
+            options.gitCommitExtraArgs.add("--signoff")
         }
     }
 }


### PR DESCRIPTION
With 0.11.2 of the Gradle plugin, the GitHub Action did nothing (due to https://github.com/gradle/wrapper-upgrade-gradle-plugin/issues/158). The issue was fixed in 0.11.3 which revealed a problem when pushing the PR branch to the GitHub repo.