### PR TITLE
Fix class-level retry with Gradle 5.0 and Suite engine or @Nested test classes

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
@@ -25,10 +25,13 @@ import org.gradle.testretry.internal.executer.framework.TestFrameworkStrategy;
 import org.gradle.testretry.internal.filter.ClassRetryMatcher;
 import org.gradle.testretry.internal.filter.RetryFilter;
 import org.gradle.testretry.internal.testsreader.TestsReader;
+import org.gradle.util.GradleVersion;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.gradle.api.tasks.testing.TestResult.ResultType.SKIPPED;
 
@@ -47,6 +50,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
 
     private final Map<Object, TestDescriptorInternal> activeDescriptorsById = new HashMap<>();
 
+    private final Set<String> testClassesSeenInCurrentRound = new HashSet<>();
     private TestNames currentRoundFailedTests = new TestNames();
     private TestNames previousRoundFailedTests = new TestNames();
 
@@ -76,6 +80,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
             delegate.started(descriptor, testStartEvent);
         } else if (!descriptor.getId().equals(rootTestDescriptorId)) {
             activeDescriptorsById.put(descriptor.getId(), descriptor);
+            registerSeenTestClass(descriptor);
             delegate.started(descriptor, testStartEvent);
         }
     }
@@ -128,6 +133,14 @@ final class RetryTestResultProcessor implements TestResultProcessor {
 
     private boolean isLifecycleFailure(String className, String name) {
         return testFrameworkStrategy.isLifecycleFailureTest(testsReader, className, name);
+    }
+
+    private void registerSeenTestClass(TestDescriptorInternal descriptor) {
+        String maybeTestClassName = descriptor.getClassName();
+
+        if (maybeTestClassName != null) {
+            testClassesSeenInCurrentRound.add(maybeTestClassName);
+        }
     }
 
     private void addRetry(String className, String name) {
@@ -207,7 +220,53 @@ final class RetryTestResultProcessor implements TestResultProcessor {
     }
 
     public RoundResult getResult() {
-        return new RoundResult(currentRoundFailedTests, previousRoundFailedTests, lastRun(), hasRetryFilteredFailures);
+        return new RoundResult(currentRoundFailedTests,
+            cleanedUpFailedTestsOfPreviousRound(),
+            lastRun(),
+            hasRetryFilteredFailures
+        );
+    }
+
+    /**
+     * When running tests via the JUnit's suite engine or using {@code @Nested} test classes,
+     * Gradle 5.0 does not report the intermediate test class nodes. This leads to a problem when such
+     * test classes are configured to be retried on class-level, as we cannot properly remove them
+     * from the previous round of failed tests without a proper test event from Gradle.
+     * <p/>
+     * For Gradle 5.0, we manually remove all test classes with no registers test methods,
+     * if we saw the test class during this round. We assume here, that those entries are
+     * just here because of the missing event from Gradle for the intermediate node.
+     * <p/>
+     * For Gradle version 5.1 and above we don't do this, as we expect events for those intermediate
+     * nodes.
+     * <p/>
+     * This solution is not perfect but still allows users to use classRetry with Gradle 5
+     * together with the suite engine and/or nested test classes.
+     *
+     * @return cleaned up failed test names of previous round
+     */
+    private TestNames cleanedUpFailedTestsOfPreviousRound() {
+        boolean isGradle50 = GradleVersion.current().getBaseVersion().equals(GradleVersion.version("5.0"));
+
+        if (isGradle50 && !testClassesSeenInCurrentRound.isEmpty() || previousRoundFailedTests.hasClassesWithoutTestNames()) {
+            TestNames testNames = new TestNames();
+            previousRoundFailedTests.stream().forEach(entry -> {
+                String testClass = entry.getKey();
+                Set<String> testMethods = entry.getValue();
+
+                if (testMethods.isEmpty()) {
+                    if (!testClassesSeenInCurrentRound.contains(testClass)) {
+                        testNames.addClass(testClass);
+                    }
+                } else {
+                    testNames.addAll(testClass, testMethods);
+                }
+            });
+
+            return testNames;
+        }
+
+        return previousRoundFailedTests;
     }
 
     public void reset(boolean lastRetry) {
@@ -216,6 +275,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
         }
 
         this.lastRetry = lastRetry;
+        this.testClassesSeenInCurrentRound.clear();
         this.previousRoundFailedTests = currentRoundFailedTests;
         this.currentRoundFailedTests = new TestNames();
         this.activeDescriptorsById.clear();

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
@@ -248,7 +248,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
     private TestNames cleanedUpFailedTestsOfPreviousRound() {
         boolean isGradle50 = GradleVersion.current().getBaseVersion().equals(GradleVersion.version("5.0"));
 
-        if (isGradle50 && !testClassesSeenInCurrentRound.isEmpty() || previousRoundFailedTests.hasClassesWithoutTestNames()) {
+        if (isGradle50 && !testClassesSeenInCurrentRound.isEmpty() && previousRoundFailedTests.hasClassesWithoutTestNames()) {
             TestNames testNames = new TestNames();
             previousRoundFailedTests.stream().forEach(entry -> {
                 String testClass = entry.getKey();

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/TestNames.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/TestNames.java
@@ -32,6 +32,10 @@ public final class TestNames {
         map.computeIfAbsent(className, ignored -> new HashSet<>()).add(testName);
     }
 
+    public void addAll(String className, Set<String> testNames) {
+        map.computeIfAbsent(className, ignored -> new HashSet<>()).addAll(testNames);
+    }
+
     public void addClass(String className) {
         map.put(className, emptySet());
     }
@@ -60,6 +64,11 @@ public final class TestNames {
                 return false;
             }
         }
+    }
+
+    public boolean hasClassesWithoutTestNames() {
+        return map.values().stream()
+            .anyMatch(Set::isEmpty);
     }
 
     public Stream<Map.Entry<String, Set<String>>> stream() {

--- a/plugin/src/test/groovy/org/gradle/testretry/internal/executer/TestNamesTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/internal/executer/TestNamesTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry.internal.executer
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TestNamesTest extends Specification {
+
+    @Subject
+    def testNames = new TestNames()
+
+    def "removing testName works properly"() {
+        given:
+        testNames.addAll("TestClass", ["test1()", "test2()", "test10()"] as Set)
+
+        when:
+        testNames.remove("TestClass", "test2()")
+
+        then:
+        methodsFor("TestClass") ==~ ["test1()", "test10()"]
+    }
+
+    def "removing testName via predicate works properly"() {
+        given:
+        testNames.addAll("TestClass", ["test1()", "test2()", "test10()"] as Set)
+
+        when:
+        testNames.remove("TestClass", testMethod -> testMethod.contains("test1"))
+
+        then:
+        methodsFor("TestClass") ==~ ["test2()"]
+    }
+
+    def "hasClassesWithoutTestNames works properly"() {
+        when:
+        testNames.add("TestClass", "test()")
+
+        then:
+        !testNames.hasClassesWithoutTestNames()
+
+        when:
+        testNames.addClass("TestClassWithNoMethods")
+
+        then:
+        testNames.hasClassesWithoutTestNames()
+    }
+
+    private Set<String> methodsFor(String testClass) {
+        def entry = testNames.stream()
+            .filter { it.key == testClass }
+            .findFirst()
+
+        assert entry.isPresent()
+
+        entry.get().value as Set
+    }
+}


### PR DESCRIPTION
This PR adds special handling when Gradle 5.0 is used.

At the end of each round, entries for test classes w/o test methods from `previousRoundFailedTests`, when using Gradle 5.0. For Gradle 5.1 and above this would automatically happen, as Gradle also reports events for intermediate classes, when JUnit's suite engine is used or when test classes are `@nested`.

To be on the safe side, we're only removing entries for test classes, if we observed this test class during the current round. It's not a perfect solution but allows using the class-retry feature of the Test Retry Gradle plugin together with test suites and nested class for Gradle 5.0 as well.

Fixes #230 
