### PR TITLE
Correctly handle retries of classes with nested classes

### DIFF
--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
@@ -634,15 +634,15 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
                 void testOk() {
                 }
 
-                @Test
-                void testFlaky() {
-                    ${flakyAssert("topLevel")}
-                }
-
                 @Nested
                 class NestedTest1 {
                     @Test
                     void testOk() {
+                    }
+
+                    @Test
+                    void testFlaky() {
+                        ${flakyAssert("topLevel")}
                     }
                 }
 
@@ -662,11 +662,12 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
         with(result.output) {
             // all methods of TopLevelTest are rerun
             it.count("${classAndMethodForNested('TopLevelTest', null, 'testOk()', gradleVersion)} PASSED") == 2
-            it.count("${classAndMethodForNested('TopLevelTest', null, 'testFlaky()', gradleVersion)} FAILED") == 1
-            it.count("${classAndMethodForNested('TopLevelTest', null, 'testFlaky()', gradleVersion)} PASSED") == 1
 
             // all methods of nested classes are retried
             it.count("${classAndMethodForNested('TopLevelTest', 'NestedTest1', 'testOk()', gradleVersion)} PASSED") == 2
+            it.count("${classAndMethodForNested('TopLevelTest', 'NestedTest1', 'testFlaky()', gradleVersion)} FAILED") == 1
+            it.count("${classAndMethodForNested('TopLevelTest', 'NestedTest1', 'testFlaky()', gradleVersion)} PASSED") == 1
+
             it.count("${classAndMethodForNested('TopLevelTest', 'NestedTest2', 'testOk()', gradleVersion)} PASSED") == 2
         }
 


### PR DESCRIPTION
## Summary
The test I implemented in https://github.com/gradle/test-retry-gradle-plugin/commit/16a68b834062ff1b11431281b537746d94653cf3 was not set up correctly to assert this behavior. All nested classes were retried because the top-level class itself had a failure and matched the retry filter. If the enclosing class did not have any method failures, then we wouldn't check if it matches the class retry filter.

With this change, we check if one of the parent classes matches the class-retry filter, and if so, retry it together with all of its nested classes.