### PR TITLE
Fix a condition that ignore maxFailures parameter for Spock Stepwise specifications

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/TestNames.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/TestNames.java
@@ -80,6 +80,9 @@ public final class TestNames {
     }
 
     public int size() {
-        return stream().mapToInt(s -> s.getValue().size()).sum();
+        return stream().mapToInt(s -> {
+            int tests = s.getValue().size();
+            return tests > 0 ? tests : 1;
+        }).sum();
     }
 }

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/TestNames.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/TestNames.java
@@ -80,9 +80,8 @@ public final class TestNames {
     }
 
     public int size() {
-        return stream().mapToInt(s -> {
-            int tests = s.getValue().size();
-            return tests > 0 ? tests : 1;
-        }).sum();
+        return stream()
+            .mapToInt(s -> Math.max(s.getValue().size(), 1)) // count number of methods, or one if we retry the class
+            .sum();
     }
 }

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseFuncTest.groovy
@@ -183,6 +183,7 @@ abstract class SpockBaseFuncTest extends AbstractFrameworkFuncTest {
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST
     }
 
+    @Issue("https://github.com/gradle/test-retry-gradle-plugin/issues/234")
     def "handles @Stepwise tests with maxFailures limit (gradle version #gradleVersion)"() {
         given:
         buildFile << """

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseFuncTest.groovy
@@ -183,6 +183,72 @@ abstract class SpockBaseFuncTest extends AbstractFrameworkFuncTest {
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST
     }
 
+    def "handles @Stepwise tests with maxFailures limit (gradle version #gradleVersion)"() {
+        given:
+        buildFile << """
+            test.retry {
+                maxRetries = 1
+                maxFailures = 1
+            }
+        """
+
+        writeGroovyTestSource """
+            package acme
+
+            @spock.lang.Stepwise
+            class StepwiseTests1 extends spock.lang.Specification {
+                def "parentTest"() {
+                    expect:
+                    true
+                }
+
+                def "childTest"() {
+                    expect:
+                    ${flakyAssert('first')}
+                }
+
+                def "grandChildTest"() {
+                    expect:
+                    true
+                }
+            }
+
+            @spock.lang.Stepwise
+            class StepwiseTests2 extends spock.lang.Specification {
+                def "parentTest"() {
+                    expect:
+                    true
+                }
+
+                def "childTest"() {
+                    expect:
+                    ${flakyAssert('second')}
+                }
+
+                def "grandChildTest"() {
+                    expect:
+                    true
+                }
+            }
+        """
+
+        when:
+        def result = gradleRunner(gradleVersion).buildAndFail()
+
+        then:
+        with(result.output) {
+            it.count('childTest FAILED') == 2
+            it.count('childTest PASSED') == 0
+            it.count('parentTest PASSED') == 2
+
+            it.count('grandChildTest SKIPPED') == 2
+            it.count('grandChildTest PASSED') == 0
+        }
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+
     def "can rerun on whole class via className (gradle version #gradleVersion)"() {
         given:
         buildFile << """


### PR DESCRIPTION
Fix an issue when Spock Stepwise specifications are ignored by maxFailures parameter.
[Detailed description (#234)](https://github.com/gradle/test-retry-gradle-plugin/issues/234)