### PR TITLE
Support develocity-testing-annotations out of the box

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -401,7 +401,7 @@ This means that all executions of the same test may not be grouped in the consol
 
 image:gradle-console-test-retry-reporting.png[Gradle console reporting, align="center", title=Flaky test Gradle console output]
 
-=== Gradle Enterprise
+=== Develocity
 
 Gradle build scans (`--scan` option) report discrete test executions as "Execution [N of total]" and will mark a test with both a _failed_ and then a _passed_ outcome as _flaky_.
 

--- a/plugin/src/main/java/org/gradle/testretry/internal/filter/ClassRetryMatcher.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/filter/ClassRetryMatcher.java
@@ -29,7 +29,8 @@ public class ClassRetryMatcher {
 
     private static final List<String> IMPLICIT_INCLUDE_ANNOTATION_CLASSES = unmodifiableList(asList(
         "spock.lang.Stepwise", // Spock's @Stepwise annotated classes must be retried as a whole
-        "com.gradle.enterprise.testing.annotations.ClassRetry" //common testing annotations
+        "com.gradle.enterprise.testing.annotations.ClassRetry", // common testing annotations
+        "com.gradle.develocity.testing.annotations.ClassRetry" // common testing annotations
     ));
 
     private final AnnotationInspector annotationInspector;


### PR DESCRIPTION
Adds support and test cases for the `@ClassRetry` annotation from the recently renamed develocity-testing-annotations 