### PR TITLE
Configure validate-distribution-url property for custom wrapper task

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -175,6 +175,7 @@ private data class VersionDownloadInfo(val version: String, val downloadUrl: Str
 
 tasks.register<Wrapper>("nightlyWrapper") {
     group = "wrapper"
+    validateDistributionUrl = true
     doFirst {
         val jsonText = URL("https://services.gradle.org/versions/nightly").readText()
         val versionInfo = Gson().fromJson(jsonText, VersionDownloadInfo::class.java)


### PR DESCRIPTION
The task `nightlyWrapper` has been failing with Gradle Nightly since Feb 7 (see [here](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_GradleNightlyDogfoodingNightly?branch=%3Cdefault%3E&buildTypeTab=overview&mode=builds)).

This PR configures the property `validateDistributionUrl` on the custom `Wrapper` task. This fixes the task again (see [here](https://e.grdev.net/s/4shkveit7mlyw/timeline#2ctkz2a5tll7a))

Nightly job: [here](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_GradleNightlyDogfoodingNightly/77880859)
Verify All job: [here](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_VerifyAll/77880865)