### PR TITLE
Add support for tests with parentheses at the end of the name

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
@@ -118,7 +118,7 @@ abstract class BaseJunitTestFrameworkStrategy implements TestFrameworkStrategy {
 
     private void addPotentiallyParameterizedSuffixed(TestFilterBuilder filters, String className, String name) {
         // It's a common pattern to add all the parameters on the end of a literal method name with []
-        String strippedParameterName = name.replaceAll("(?:\\([^)]*?\\)|\\[[^]]*?])*$", "");
+        String strippedParameterName = name.replaceAll("(?:\\([^)]*?\\))?(?:\\[[^]]*?](?:\\([^)]*?\\))?)?$", "");
         filters.test(className, strippedParameterName);
         filters.test(className, name);
     }

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
@@ -118,7 +118,11 @@ abstract class BaseJunitTestFrameworkStrategy implements TestFrameworkStrategy {
 
     private void addPotentiallyParameterizedSuffixed(TestFilterBuilder filters, String className, String name) {
         // It's a common pattern to add all the parameters on the end of a literal method name with []
-        String strippedParameterName = name.replaceAll("(?:\\([^)]*?\\))?(?:\\[[^]]*?](?:\\([^)]*?\\))?)?$", "");
+        // The regex takes care of removing trailing (...) or (...)[...], for e.g. the following cases
+        // * `test that contains (parentheses)()`
+        // * `test that contains (parentheses)(int, int)[1]`
+        // * `test(1, true) [0]`
+        String strippedParameterName = name.replaceAll("(?:\\([^)]*?\\))?(?:\\[[^]]*?])?$", "");
         filters.test(className, strippedParameterName);
         filters.test(className, name);
     }

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
@@ -30,10 +30,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 abstract class BaseJunitTestFrameworkStrategy implements TestFrameworkStrategy {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(JunitTestFrameworkStrategy.class);
+    private static final Pattern PARAMETERIZED_SUFFIX_PATTERN = Pattern.compile("(?:\\([^)]*?\\))?(?:\\[[^]]*?])?$");
     static final Set<String> ERROR_SYNTHETIC_TEST_NAMES = Collections.unmodifiableSet(
         new HashSet<>(Arrays.asList(
             "classMethod",
@@ -122,7 +124,7 @@ abstract class BaseJunitTestFrameworkStrategy implements TestFrameworkStrategy {
         // * `test that contains (parentheses)()`
         // * `test that contains (parentheses)(int, int)[1]`
         // * `test(1, true) [0]`
-        String strippedParameterName = name.replaceAll("(?:\\([^)]*?\\))?(?:\\[[^]]*?])?$", "");
+        String strippedParameterName = PARAMETERIZED_SUFFIX_PATTERN.matcher(name).replaceAll("");
         filters.test(className, strippedParameterName);
         filters.test(className, name);
     }

--- a/plugin/src/test/groovy/org/gradle/testretry/AbstractGeneralPluginFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/AbstractGeneralPluginFuncTest.groovy
@@ -24,7 +24,7 @@ abstract class AbstractGeneralPluginFuncTest extends AbstractPluginFuncTest {
     }
 
     protected void successfulTest() {
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             public class SuccessfulTests {
@@ -35,7 +35,7 @@ abstract class AbstractGeneralPluginFuncTest extends AbstractPluginFuncTest {
     }
 
     protected void failedTest() {
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             import static org.junit.Assert.assertTrue;
@@ -50,7 +50,7 @@ abstract class AbstractGeneralPluginFuncTest extends AbstractPluginFuncTest {
     }
 
     protected void flakyTest() {
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             public class FlakyTests {

--- a/plugin/src/test/groovy/org/gradle/testretry/AbstractPluginFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/AbstractPluginFuncTest.groovy
@@ -46,8 +46,9 @@ abstract class AbstractPluginFuncTest extends Specification {
 
         testProjectDir.newFolder('src', 'test', 'java', 'acme')
         testProjectDir.newFolder('src', 'test', 'groovy', 'acme')
+        testProjectDir.newFolder('src', 'test', 'kotlin', 'acme')
 
-        writeTestSource flakyAssertClass()
+        writeJavaTestSource flakyAssertClass()
     }
 
     String markerFileExistsCheck(String id = "id") {
@@ -138,10 +139,6 @@ abstract class AbstractPluginFuncTest extends Specification {
         baseBuildScript().replace("id 'org.gradle.test-retry'", "id 'org.gradle.test-retry' apply false")
     }
 
-    String testLanguage() {
-        'java'
-    }
-
     protected String buildConfiguration() {
         return 'dependencies { testImplementation "junit:junit:4.13.2" }'
     }
@@ -155,22 +152,28 @@ abstract class AbstractPluginFuncTest extends Specification {
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")
-    void writeTestSource(String source) {
+    void writeTestSource(
+        String source,
+        String language,
+        String extension
+    ) {
         String packageName = (source =~ /package\s+([\w.]+)/)[0][1]
         String className = (source =~ /(class|interface)\s+(\w+)\s+/)[0][2]
-        String sourceFilePackage = "src/test/${testLanguage()}/${packageName.replace('.', '/')}"
+        String sourceFilePackage = "src/test/$language/${packageName.replace('.', '/')}"
         new File(testProjectDir.root, sourceFilePackage).mkdirs()
-        testProjectDir.newFile("$sourceFilePackage/${className}.${testLanguage()}") << source
+        testProjectDir.newFile("$sourceFilePackage/${className}.$extension") << source
     }
 
     void writeJavaTestSource(@Language("JAVA") String source) {
-        assert testLanguage() == 'java'
-        writeTestSource(source)
+        writeTestSource(source, 'java', 'java')
     }
 
     void writeGroovyTestSource(@Language("Groovy") String source) {
-        assert testLanguage() == 'groovy'
-        writeTestSource(source)
+        writeTestSource(source, 'groovy', 'groovy')
+    }
+
+    void writeKotlinTestSource(@Language("kotlin") String source) {
+        writeTestSource(source, 'kotlin', 'kt')
     }
 
     GradleRunner gradleRunner(String gradleVersion, String... arguments = ['test', '-S']) {

--- a/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.testretry
 
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.GradleVersion
+import static groovy.lang.Tuple2.tuple
 
 class ParenthesesFuncTest extends AbstractPluginFuncTest {
 
@@ -42,10 +43,10 @@ class ParenthesesFuncTest extends AbstractPluginFuncTest {
             // Kotlin plugin compatible from 6.8 onwards
             GRADLE_VERSIONS_UNDER_TEST.findAll { GradleVersion.version(it) >= GradleVersion.version("6.8") },
             [
-                new Tuple2<>({ bf -> setupJunit5Test(bf) }, junit5TestWithParentheses()),
-                new Tuple2<>({ bf -> setupJunit5Test(bf) }, junit5ParameterizedTestWithParentheses()),
-                new Tuple2<>({ bf -> setupJunit4Test(bf) }, junit4TestWithJUnitParams()),
-                new Tuple2<>({ bf -> setupJunit4Test(bf) }, junit4TestWithJUnitParamsWithTestCaseName())
+                tuple({ bf -> setupJunit5Test(bf) }, junit5TestWithParentheses()),
+                tuple({ bf -> setupJunit5Test(bf) }, junit5ParameterizedTestWithParentheses()),
+                tuple({ bf -> setupJunit4Test(bf) }, junit4TestWithJUnitParams()),
+                tuple({ bf -> setupJunit4Test(bf) }, junit4TestWithJUnitParamsWithTestCaseName())
             ]
         ].combinations()
     }

--- a/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
@@ -44,7 +44,8 @@ class ParenthesesFuncTest extends AbstractPluginFuncTest {
             [
                 new Tuple2<>({ bf -> setupJunit5Test(bf) }, junit5TestWithParentheses()),
                 new Tuple2<>({ bf -> setupJunit5Test(bf) }, junit5ParameterizedTestWithParentheses()),
-                new Tuple2<>({ bf -> setupJunit4Test(bf) }, junit4TestWithJUnitParams())
+                new Tuple2<>({ bf -> setupJunit4Test(bf) }, junit4TestWithJUnitParams()),
+                new Tuple2<>({ bf -> setupJunit4Test(bf) }, junit4TestWithJUnitParamsWithTestCaseName())
             ]
         ].combinations()
     }
@@ -97,6 +98,30 @@ class ParenthesesFuncTest extends AbstractPluginFuncTest {
 
                 @Test
                 @Parameters("1, true")
+                fun test(foo: Int, bar: Boolean) {
+                    assert(foo != 0)
+                    assert(bar)
+                    ${flakyAssert()}
+                }
+            }
+        """
+    }
+
+    private static String junit4TestWithJUnitParamsWithTestCaseName() {
+        """
+            package acme
+
+            import junitparams.*
+            import junitparams.naming.*
+            import org.junit.Test
+            import org.junit.runner.RunWith
+
+            @RunWith(JUnitParamsRunner::class)
+            class Test1 {
+
+                @Test
+                @Parameters("1, true")
+                @TestCaseName("{method}[{index}: {method}({0})={1}]")
                 fun test(foo: Int, bar: Boolean) {
                     assert(foo != 0)
                     assert(bar)

--- a/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
@@ -15,9 +15,7 @@
  */
 package org.gradle.testretry
 
-import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
-import org.gradle.util.GradleVersion
 
 class ParenthesesFuncTest extends AbstractPluginFuncTest {
 

--- a/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testretry
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.util.GradleVersion
+
+class ParenthesesFuncTest extends AbstractPluginFuncTest {
+
+    private static final GradleVersion GRADLE_8_3 = GradleVersion.version("8.3")
+    private static final String MIN_JUPITER_VERSION_DRY_RUN = "5.10.0-RC1"
+    private static final String MIN_PLATFORM_VERSION_DRY_RUN = "1.10.0-RC1"
+
+    @Override
+    String getLanguagePlugin() {
+        "org.jetbrains.kotlin.jvm' version '1.9.23"
+    }
+
+    def "should work with parentheses in test name"() {
+        given:
+//        buildFile.delete()
+//        buildFile = testProjectDir.newFile('build.gradle.kts')
+        buildFile << """
+            dependencies {
+//                testImplementation "org.jetbrains.kotlin:kotlin-test"
+                testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+//                testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+            }
+
+            test {
+                useJUnitPlatform()
+                retry {
+                    maxRetries = 2
+                    failOnPassedAfterRetry = false
+                }
+            }
+        """
+
+        and:
+        writeKotlinTestSource """
+            package acme
+            
+            import org.junit.jupiter.api.Test
+
+            class DemoTest {
+            
+                @Test
+                fun `test that does not contain parentheses`() {
+                    assert(true)
+                }
+            
+                @Test
+                fun `test that contains (parentheses)`() {
+                    ${flakyAssert()}
+                }
+            }
+        """
+
+        expect:
+        def result = gradleRunner(gradleVersion, "test").build()
+        !result.output.isEmpty()
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+
+    private void setupTest(boolean gradle83OrAbove, boolean withTestDryRun) {
+        setupTest(gradle83OrAbove, withTestDryRun, Optional.empty())
+    }
+
+    private void setupTest(boolean gradle83OrAbove, boolean withTestDryRun, Optional<Boolean> withSysPropDryRun) {
+        buildFile << """
+            test {
+                useJUnitPlatform()
+                ${gradle83OrAbove && withTestDryRun ? "dryRun = true" : ""}
+                ${withSysPropDryRun.map { it -> gradle83OrAbove && it ? "systemProperty('junit.platform.execution.dryRun.enabled', $it)" : "" }.orElse("")}
+                retry {
+                    maxRetries = 1
+                }
+            }
+        """
+    }
+
+    private void successfulJUnit5Test() {
+        writeKotlinTestSource """
+            package acme;
+
+            public class SuccessfulTests {
+                @org.junit.jupiter.api.Test
+                public void successTest() {}
+            }
+        """
+    }
+
+    private static boolean methodPassed(BuildResult result) {
+        return result.output.count('PASSED') == 1
+    }
+
+    private static boolean methodSkipped(BuildResult result) {
+        return result.output.count('SKIPPED') == 1
+    }
+}

--- a/plugin/src/test/groovy/org/gradle/testretry/TestDryRunFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/TestDryRunFuncTest.groovy
@@ -146,7 +146,7 @@ class TestDryRunFuncTest extends AbstractGeneralPluginFuncTest {
     }
 
     private void successfulJUnit5Test() {
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             public class SuccessfulTests {

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/MockitoFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/MockitoFuncTest.groovy
@@ -34,7 +34,7 @@ class MockitoFuncTest extends AbstractFrameworkFuncTest {
             test.retry.maxRetries = 1
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             import org.junit.*;

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockBaseFuncTest.groovy
@@ -1201,11 +1201,6 @@ abstract class SpockBaseFuncTest extends AbstractFrameworkFuncTest {
     }
 
     @Override
-    String testLanguage() {
-        'groovy'
-    }
-
-    @Override
     protected String buildConfiguration() {
         return """
             dependencies {

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGFuncTest.groovy
@@ -39,7 +39,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             test.retry.maxRetries = 1
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             public class SuccessfulTests {
@@ -77,7 +77,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             test.retry.maxRetries = 1
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             public class SomeTests {
@@ -110,7 +110,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             test.retry.maxRetries = 1
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             import org.testng.annotations.*;
@@ -130,7 +130,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             }
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             public class ParameterTest extends AbstractTest {
@@ -157,7 +157,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             test.retry.maxRetries = 1
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             abstract class AbstractTest {
@@ -168,7 +168,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             }
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             public class FlakyTests extends AbstractTest {
@@ -198,7 +198,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             test.retry.maxRetries = 1
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             import org.testng.annotations.*;
@@ -240,7 +240,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             test.retry.maxRetries = 1
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             import org.testng.annotations.*;
@@ -281,7 +281,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             test.retry.maxRetries = 1
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             import org.testng.annotations.*;
@@ -345,7 +345,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             }
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             public class SomeTests {
@@ -356,7 +356,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             }
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
 
             public class LoggingTestListener extends org.testng.TestListenerAdapter {
@@ -389,7 +389,7 @@ class TestNGFuncTest extends AbstractFrameworkFuncTest {
             test.retry.maxRetries = 1
         """
 
-        writeTestSource """
+        writeJavaTestSource """
             package acme;
             import org.testng.annotations.*;
             import java.nio.file.*;


### PR DESCRIPTION
* Add support for tests with parentheses at the end of the name by modifying the regex in `BaseJunitTestFrameworkStrategy.addPotentiallyParameterizedSuffixed()`, to only remove `(...)`, or `(...)[...]`, without matching an arbitrary number of parentheses / brackets, as was the case up until now
* Removes `AbstractPluginFuncTest.testLanguage()` and modifies the signature of `AbstractPluginFuncTest.writeTestSource`, to allow creating kotlin sample test classes
* Adds `ParenthesesFuncTest`, that tests https://github.com/gradle/test-retry-gradle-plugin/issues/101, https://github.com/gradle/test-retry-gradle-plugin/issues/123, and https://github.com/gradle/test-retry-gradle-plugin/issues/263 