### PR TITLE
Account for different formats of reported display name

### DIFF
--- a/plugin/src/test/groovy/org/gradle/testretry/FilterFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/FilterFuncTest.groovy
@@ -47,7 +47,7 @@ class FilterFuncTest extends AbstractGeneralPluginFuncTest {
         noRetry << test("BaseIncludedAndExcludedTest", "BaseIncludedTest", "InheritedExcludedAnnotation")
         noRetry << test("IncludedAndExcludedInheritedTest", "BaseIncludedAndExcludedTest")
         shouldRetry << test("IncludedNonInheritedTest", null, "NonInheritedIncludedAnnotation")
-        noRetry << test("ExcludedTest", null, "NonInheritedIncludedAnnotation")
+        noRetry << test("StandaloneExcludedTest", null, "NonInheritedIncludedAnnotation")
         noRetry << test("IncludeWithBadAnnotation", null, "InheritedExcludedAnnotation")
 
         when:
@@ -56,14 +56,14 @@ class FilterFuncTest extends AbstractGeneralPluginFuncTest {
         then:
         noRetry.each { testName ->
             with(result.output) {
-                it.count("acme.${testName} > flakyTest FAILED") == 1
-                it.count("acme.${testName} > flakyTest PASSED") == 0
+                it.count("${testName} > flakyTest FAILED") == 1
+                it.count("${testName} > flakyTest PASSED") == 0
             }
         }
         shouldRetry.each { testName ->
             with(result.output) {
-                it.count("acme.${testName} > flakyTest FAILED") == 2
-                it.count("acme.${testName} > flakyTest PASSED") == 1
+                it.count("${testName} > flakyTest FAILED") == 2
+                it.count("${testName} > flakyTest PASSED") == 1
             }
         }
 
@@ -126,8 +126,8 @@ class FilterFuncTest extends AbstractGeneralPluginFuncTest {
 
         then:
         with(result.output) {
-            it.count("acme.ExcludedTest > flakyTest FAILED") == 1
-            it.count("acme.ExcludedTest > flakyTest PASSED") == 0
+            it.count("ExcludedTest > flakyTest FAILED") == 1
+            it.count("ExcludedTest > flakyTest PASSED") == 0
         }
 
         where:

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/MockitoFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/MockitoFuncTest.groovy
@@ -66,7 +66,7 @@ class MockitoFuncTest extends AbstractFrameworkFuncTest {
 
         then:
         with(result.output) {
-            it.count('acme.TestWithUnnecessaryStubbings > unnecessary Mockito stubbings FAILED') == 2
+            it.count('TestWithUnnecessaryStubbings > unnecessary Mockito stubbings FAILED') == 2
             !it.contains("unable to retry the following test methods, which is unexpected.")
         }
 


### PR DESCRIPTION
Gradle 8.8+ will propagate the reported display name from JUnit. This change updates impacted assertions to work both with new and old output formats. See https://e.grdev.net/s/stn5aqybyzdt2/tests/task/:plugin:testGradleNightlies/details/org.gradle.testretry.FilterFuncTest/can%20filter%20what%20is%20retried%20(gradle%20version%208.8-20240406001318%2B0000)?top-execution=1