### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ org.gradle.parallel=true
 systemProp.org.gradle.kotlin.dsl.caching.buildcache=true
 systemProp.scan.capture-task-input-files=true
 systemProp.org.gradle.groovy.compilation.avoidance=true
+systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
This system property will disable sending `maven-metadata.xml.sha512` files to our repository. The files are not correctly handled by the repository.