### PR TITLE
Add a GitHub action to automatically add issues/PRs to the team board

### DIFF
--- a/.github/workflows/add-issue-to-team-board.yml
+++ b/.github/workflows/add-issue-to-team-board.yml
@@ -1,0 +1,18 @@
+name: 'Add issue/PR to the team board'
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    name: Add issue/PR to the team board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.1
+        with:
+          # Testing team's project board
+          project-url: https://github.com/orgs/gradle/projects/27
+          github-token: ${{ secrets.GH_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

I see new issues/PRs only by occasionally opening the repo and explicitly checking for those. This workflow will make new issues and PRs visible to us by automatically adding them to our board.