### PR TITLE
Implement CI fanout for Gradle cross version tests

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -163,8 +163,14 @@ tasks.test {
     )
 }
 
-tasks.register<Test>("testGradleReleases") {
-    jvmArgumentProviders.add(GradleVersionsCommandLineArgumentProvider(GradleVersionData::getReleasedVersions))
+listOf(5, 6, 7, 8).map { gradleMajorVersion ->
+    tasks.register<Test>("testGradle${gradleMajorVersion}Releases") {
+        jvmArgumentProviders.add(GradleVersionsCommandLineArgumentProvider {
+            GradleVersionData.getReleasedVersions(
+                gradleMajorVersion
+            )
+        })
+    }
 }
 
 tasks.register<Test>("testGradleNightlies") {


### PR DESCRIPTION
## Description

For the release of the plugin, we require a successful ["Verify All"](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_VerifyAll?branch=%3Cdefault%3E&buildTypeTab=overview&mode=builds) job for the release commit. This job depends on 3 other jobs: 
* [Quick Feedback](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_QuickFeedback?branch=%3Cdefault%3E&buildTypeTab=overview&mode=builds), which is equivalent to the PR build that runs all tests using the current Gradle version.
* [CrossVersionTest Gradle Nightlies](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_CrossVersionTestGradleNightliesLinuxJava18?branch=%3Cdefault%3E&buildTypeTab=overview&mode=builds), which runs the same tests against nightly versions of Gradle.
* [CrossVersionTest Gradle Releases](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_CrossVersionTestGradleReleasesLinuxJava18?branch=%3Cdefault%3E&buildTypeTab=overview&mode=builds), which runs the same tests but for all latest path versions of Gradle (starting with Gradle 5.0).

While the first two jobs are relatively quick (both taking around 8m), the last one is painfully slow, taking between 4 and 7 hours to complete based on the agent used. This effectively means that we cannot complete a release within a day, as this build takes the majority of the work day.

I suggest splitting this job into multiple ones, which will run tests only for a certain major Gradle version. This would allow us to run them in parallel and hopefully cut the waiting time by approximately 75% from 6 hours to 1.5.

Using Test Distribution is not an option in the current setup. We have very few test classes with not that many test methods. However, Gradle versions are fed as test parameters, meaning that for the "Releases" job, each method has 35 iterations. And those will be scheduled as a single unit by TD.