### PR TITLE
Switch to develocity.grdev.net for publishing builds

### DIFF
--- a/gradle/init-scripts/build-scan.init.gradle.kts
+++ b/gradle/init-scripts/build-scan.init.gradle.kts
@@ -15,7 +15,7 @@ if (!gradle.startParameter.systemPropertiesArgs.containsKey("disableScanPlugin")
 fun configureExtension(extension: Any) {
     extension.withGroovyBuilder {
         "publishAlways"()
-        setProperty("server", "https://e.grdev.net")
+        setProperty("server", "https://develocity.grdev.net")
         if (System.getenv("CI") !in listOf(null, "false")) {
             "tag"("CI")
         }


### PR DESCRIPTION
Since e.grdev.net is soon read-only, we should switch to the new internal DV instance.

I believe the access key for the new server is already configured in TeamCity. But we'll see...

Verify All job for this PR: [here](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_VerifyAll?branch=snoopcheri%2Fswitch-internal-server&buildTypeTab=overview&mode=builds)

TC Job demonstrating that uploading build scan to new server works: [here](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_CrossVersionTestGradle7xReleasesLinuxJava18/87236351)