### PR TITLE
Add failOnSkippedAfterRetry option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,6 +47,7 @@ test {
         maxRetries = 2
         maxFailures = 20
         failOnPassedAfterRetry = true
+        failOnSkippedAfterRetry = true
     }
 }
 ----
@@ -60,6 +61,7 @@ test {
         maxRetries.set(2)
         maxFailures.set(20)
         failOnPassedAfterRetry.set(true)
+        failOnSkippedAfterRetry.set(true)
     }
 }
 ----
@@ -79,6 +81,7 @@ test {
             maxFailures = 20
         }
         failOnPassedAfterRetry = true
+        failOnSkippedAfterRetry = true
     }
 }
 ----
@@ -119,6 +122,18 @@ public interface TestRetryTaskExtension {
      * @return whether tests that initially fails and then pass on retry should fail the task
      */
     Property<Boolean> getFailOnPassedAfterRetry();
+
+    /**
+     * Whether tests that initially fail and then are skipped on retry should fail the task.
+     * <p>
+     * This setting defaults to {@code true} (for backward compatibility),
+     * which results in the task failing if any of tests skip on retry.
+     * <p>
+     * This setting has no effect if {@link Test#getIgnoreFailures()} is set to true.
+     *
+     * @return whether tests that initially fails and then are skipped on retry should fail the task
+     */
+    Property<Boolean> getFailOnSkippedAfterRetry();
 
     /**
      * The maximum number of times to retry an individual test.

--- a/plugin/src/main/java/org/gradle/testretry/TestRetryTaskExtension.java
+++ b/plugin/src/main/java/org/gradle/testretry/TestRetryTaskExtension.java
@@ -45,6 +45,18 @@ public interface TestRetryTaskExtension {
     Property<Boolean> getFailOnPassedAfterRetry();
 
     /**
+     * Whether tests that initially fail and then are skipped on retry should fail the task.
+     * <p>
+     * This setting defaults to {@code true} (for backward compatibility),
+     * which results in the task failing if any of tests skip on retry.
+     * <p>
+     * This setting has no effect if {@link Test#getIgnoreFailures()} is set to true.
+     *
+     * @return whether tests that initially fails and then are skipped on retry should fail the task
+     */
+    Property<Boolean> getFailOnSkippedAfterRetry();
+
+    /**
      * The maximum number of times to retry an individual test.
      * <p>
      * This setting defaults to {@code 0}, which results in no retries.

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/DefaultTestRetryTaskExtension.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/DefaultTestRetryTaskExtension.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
 
     private final Property<Boolean> failOnPassedAfterRetry;
+    private final Property<Boolean> failOnSkippedAfterRetry;
     private final Property<Integer> maxRetries;
     private final Property<Integer> maxFailures;
     private final Filter filter;
@@ -35,6 +36,7 @@ public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
     @Inject
     public DefaultTestRetryTaskExtension(ObjectFactory objects) {
         this.failOnPassedAfterRetry = objects.property(Boolean.class);
+        this.failOnSkippedAfterRetry = objects.property(Boolean.class);
         this.maxRetries = objects.property(Integer.class);
         this.maxFailures = objects.property(Integer.class);
         this.filter = new FilterImpl(objects);
@@ -43,6 +45,10 @@ public class DefaultTestRetryTaskExtension implements TestRetryTaskExtension {
 
     public Property<Boolean> getFailOnPassedAfterRetry() {
         return failOnPassedAfterRetry;
+    }
+
+    public Property<Boolean> getFailOnSkippedAfterRetry() {
+        return failOnSkippedAfterRetry;
     }
 
     public Property<Integer> getMaxRetries() {

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAccessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAccessor.java
@@ -21,6 +21,8 @@ public interface TestRetryTaskExtensionAccessor {
 
     boolean getFailOnPassedAfterRetry();
 
+    boolean getFailOnSkippedAfterRetry();
+
     int getMaxRetries();
 
     int getMaxFailures();

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestRetryTaskExtensionAdapter.java
@@ -36,6 +36,7 @@ public final class TestRetryTaskExtensionAdapter implements TestRetryTaskExtensi
     private static final int DEFAULT_MAX_RETRIES = 0;
     private static final int DEFAULT_MAX_FAILURES = 0;
     private static final boolean DEFAULT_FAIL_ON_PASSED_AFTER_RETRY = false;
+    private static final boolean DEFAULT_FAIL_ON_SKIPPED_AFTER_RETRY = true;
 
     private final ProviderFactory providerFactory;
     private final TestRetryTaskExtension extension;
@@ -62,6 +63,7 @@ public final class TestRetryTaskExtensionAdapter implements TestRetryTaskExtensi
             extension.getMaxRetries().convention(DEFAULT_MAX_RETRIES);
             extension.getMaxFailures().convention(DEFAULT_MAX_FAILURES);
             extension.getFailOnPassedAfterRetry().convention(DEFAULT_FAIL_ON_PASSED_AFTER_RETRY);
+            extension.getFailOnSkippedAfterRetry().convention(DEFAULT_FAIL_ON_SKIPPED_AFTER_RETRY);
             filter.getIncludeClasses().convention(emptySet());
             filter.getIncludeAnnotationClasses().convention(emptySet());
             filter.getExcludeClasses().convention(emptySet());
@@ -93,9 +95,28 @@ public final class TestRetryTaskExtensionAdapter implements TestRetryTaskExtensi
         }
     }
 
+    Callable<Provider<Boolean>> getFailOnSkippedAfterRetryInput() {
+        if (useConventions) {
+            return extension::getFailOnSkippedAfterRetry;
+        } else {
+            return () -> {
+                if (extension.getFailOnSkippedAfterRetry().isPresent()) {
+                    return extension.getFailOnSkippedAfterRetry();
+                } else {
+                    return providerFactory.provider(TestRetryTaskExtensionAdapter.this::getFailOnSkippedAfterRetry);
+                }
+            };
+        }
+    }
+
     @Override
     public boolean getFailOnPassedAfterRetry() {
         return read(extension.getFailOnPassedAfterRetry(), DEFAULT_FAIL_ON_PASSED_AFTER_RETRY);
+    }
+
+    @Override
+    public boolean getFailOnSkippedAfterRetry() {
+        return read(extension.getFailOnSkippedAfterRetry(), DEFAULT_FAIL_ON_SKIPPED_AFTER_RETRY);
     }
 
     @Override

--- a/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/config/TestTaskConfigurer.java
@@ -54,6 +54,8 @@ public final class TestTaskConfigurer {
 
         test.getInputs().property("retry.failOnPassedAfterRetry", adapter.getFailOnPassedAfterRetryInput());
 
+        test.getInputs().property("retry.failOnSkippedAfterRetry", adapter.getFailOnSkippedAfterRetryInput());
+
         Provider<Boolean> shouldReplaceTestExecutor = shouldReplaceTestExecutor(test, objectFactory, providerFactory, gradleVersion);
         test.getInputs().property("isDeactivatedByTestDistributionPlugin", shouldReplaceTestExecutor);
 

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestExecuter.java
@@ -72,6 +72,7 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
         int maxRetries = extension.getMaxRetries();
         int maxFailures = extension.getMaxFailures();
         boolean failOnPassedAfterRetry = extension.getFailOnPassedAfterRetry();
+        boolean failOnSkippedAfterRetry = extension.getFailOnSkippedAfterRetry();
 
         if (maxRetries <= 0) {
             delegate.execute(spec, testResultProcessor);
@@ -106,7 +107,8 @@ public final class RetryTestExecuter implements TestExecuter<JvmTestExecutionSpe
             classRetryMatcher,
             frameworkTemplate.testsReader,
             testResultProcessor,
-            maxFailures
+            maxFailures,
+            failOnSkippedAfterRetry
         );
 
         int retryCount = 0;

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/RetryTestResultProcessor.java
@@ -47,6 +47,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
     private final TestResultProcessor delegate;
 
     private final int maxFailures;
+    private final boolean failOnSkippedAfterRetry;
     private boolean lastRetry;
     private boolean hasRetryFilteredFailures;
     private Method failureMethod;
@@ -66,7 +67,8 @@ final class RetryTestResultProcessor implements TestResultProcessor {
         ClassRetryMatcher classRetryMatcher,
         TestsReader testsReader,
         TestResultProcessor delegate,
-        int maxFailures
+        int maxFailures,
+        boolean failOnSkippedAfterRetry
     ) {
         this.testFrameworkStrategy = testFrameworkStrategy;
         this.filter = filter;
@@ -74,6 +76,7 @@ final class RetryTestResultProcessor implements TestResultProcessor {
         this.testsReader = testsReader;
         this.delegate = delegate;
         this.maxFailures = maxFailures;
+        this.failOnSkippedAfterRetry = failOnSkippedAfterRetry;
     }
 
     @Override
@@ -107,7 +110,8 @@ final class RetryTestResultProcessor implements TestResultProcessor {
                 String name = descriptor.getName();
 
                 boolean failedInPreviousRound = previousRoundFailedTests.remove(className, name);
-                if (failedInPreviousRound && testCompleteEvent.getResultType() == SKIPPED) {
+                boolean shouldRetrySkippedTestThatPreviouslyFailed = failedInPreviousRound && testCompleteEvent.getResultType() == SKIPPED && failOnSkippedAfterRetry;
+                if (shouldRetrySkippedTestThatPreviouslyFailed) {
                     addRetry(descriptor);
                 }
 


### PR DESCRIPTION
If a test is set to be skipped on it's body if certain condition meets, a retried test that is later skipped will fail the build.
Adding this option allows you to choose the behavior you want.

There is issue for this problem:
[#130](https://github.com/gradle/test-retry-gradle-plugin/issues/130)