### PR TITLE
Add support for dynamic tests

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
@@ -159,10 +159,11 @@ abstract class BaseJunitTestFrameworkStrategy implements TestFrameworkStrategy {
 
     private void addPotentiallyParameterizedSuffixed(TestFilterBuilder filters, String className, String name) {
         // It's a common pattern to add all the parameters on the end of a literal method name with []
-        // The regex takes care of removing trailing (...) or (...)[...], for e.g. the following cases
+        // The regex takes care of removing trailing (...) or (...)[...], or (...)[...][...] for e.g. the following cases
         // * `test that contains (parentheses)()`
         // * `test that contains (parentheses)(int, int)[1]`
         // * `test(1, true) [0]`
+        // * `dynamicContainerTest()[1][1]`
         String strippedParameterName = PARAMETERIZED_SUFFIX_PATTERN.matcher(name).replaceAll("");
         filters.test(className, strippedParameterName);
         filters.test(className, name);

--- a/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/executer/framework/BaseJunitTestFrameworkStrategy.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 abstract class BaseJunitTestFrameworkStrategy implements TestFrameworkStrategy {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(JunitTestFrameworkStrategy.class);
-    private static final Pattern PARAMETERIZED_SUFFIX_PATTERN = Pattern.compile("(?:\\([^)]*?\\))?(?:\\[[^]]*?])?$");
+    private static final Pattern PARAMETERIZED_SUFFIX_PATTERN = Pattern.compile("(?:\\([^)]*?\\))?(?:\\[[^]]*?])*$");
     private static final String ERROR_SYNTHETIC_TESTNG_CLASS_NAME = "UnknownClass";
     static final Set<String> ERROR_SYNTHETIC_TEST_NAMES = Collections.unmodifiableSet(
         new HashSet<>(Arrays.asList(

--- a/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
@@ -157,7 +157,7 @@ class ParenthesesFuncTest extends AbstractPluginFuncTest {
     private static String junit5ParameterizedTestWithParentheses() {
         """
             package acme
-            
+
             import org.junit.jupiter.params.ParameterizedTest;
             import org.junit.jupiter.params.provider.Arguments;
             import org.junit.jupiter.params.provider.MethodSource;
@@ -170,7 +170,7 @@ class ParenthesesFuncTest extends AbstractPluginFuncTest {
                     assert(a == b)
                     ${flakyAssert()}
                 }
-                
+
                 companion object {
                     @JvmStatic
                     fun data() = listOf(

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
@@ -752,20 +752,7 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
 
         then:
         def gv = GradleVersion.version(gradleVersion)
-        def testname
-        if (gv >= GradleVersion.version("8.8")) {
-            testname = 'MyTest > dynamicContainerTest() > container > test name 1'
-        } else if ((gv >= GradleVersion.version("8.1") && gv < GradleVersion.version("8.8")) || (gv >= GradleVersion.version("7.6") && gv < GradleVersion.version("8.0"))) {
-            testname = 'MyTest > dynamicContainerTest() > container > acme.MyTest.test name 1'
-        } else if ((gv >= GradleVersion.version("7.0") && gv < GradleVersion.version("7.6")) || (gv >= GradleVersion.version("8.0") && gv < GradleVersion.version("8.1"))) {
-            testname = 'MyTest > dynamicContainerTest() > container > acme.MyTest.dynamicContainerTest()[1][1]'
-        } else if ((gv >= GradleVersion.version("6.7") && gv < GradleVersion.version("7.0")) || (gv >= GradleVersion.version("6.1") && gv < GradleVersion.version("6.6"))) {
-            testname = 'MyTest > test name 1'
-        } else if (gv >= GradleVersion.version("6.6") && gv < GradleVersion.version("6.7")) {
-            testname = 'acme.MyTest > test name 1'
-        } else {
-            testname = 'acme.MyTest > dynamicContainerTest()[1][1]'
-        }
+        def testname = dynamicTestName(gv)
 
         with(result.output) {
             it.count("${testname} FAILED") == 1
@@ -774,6 +761,22 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
 
         where:
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+
+    private static String dynamicTestName(GradleVersion gv) {
+        if (gv >= GradleVersion.version("8.8")) {
+            return 'MyTest > dynamicContainerTest() > container > test name 1'
+        } else if ((gv >= GradleVersion.version("8.1") && gv < GradleVersion.version("8.8")) || (gv >= GradleVersion.version("7.6") && gv < GradleVersion.version("8.0"))) {
+            return 'MyTest > dynamicContainerTest() > container > acme.MyTest.test name 1'
+        } else if ((gv >= GradleVersion.version("7.0") && gv < GradleVersion.version("7.6")) || (gv >= GradleVersion.version("8.0") && gv < GradleVersion.version("8.1"))) {
+            return 'MyTest > dynamicContainerTest() > container > acme.MyTest.dynamicContainerTest()[1][1]'
+        } else if ((gv >= GradleVersion.version("6.7") && gv < GradleVersion.version("7.0")) || (gv >= GradleVersion.version("6.1") && gv < GradleVersion.version("6.6"))) {
+            return 'MyTest > test name 1'
+        } else if (gv >= GradleVersion.version("6.6") && gv < GradleVersion.version("6.7")) {
+            return 'acme.MyTest > test name 1'
+        } else {
+            return 'acme.MyTest > dynamicContainerTest()[1][1]'
+        }
     }
 
     String reportedTestName(String testName) {


### PR DESCRIPTION
Updates `PARAMETERIZED_SUFFIX_PATTERN` in `BaseJunitTestFrameworkStrategy` to support dynamic tests, by allowing an arbitrary number of trailing `[...]`