### PR TITLE
Configure Git credential helper for tagging the release

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -77,13 +77,13 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.teamcity</groupId>
-      <artifactId>configs-dsl-kotlin</artifactId>
+      <artifactId>configs-dsl-kotlin-latest</artifactId>
       <version>${teamcity.dsl.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.teamcity</groupId>
-      <artifactId>configs-dsl-kotlin-plugins</artifactId>
+      <artifactId>configs-dsl-kotlin-plugins-latest</artifactId>
       <version>1.0-SNAPSHOT</version>
       <type>pom</type>
       <scope>compile</scope>

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,12 +1,12 @@
-import jetbrains.buildServer.configs.kotlin.v2019_2.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildTypeSettings.Type.COMPOSITE
-import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
-import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay.NORMAL
-import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay.PROMPT
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.project
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
-import jetbrains.buildServer.configs.kotlin.v2019_2.version
+import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.BuildTypeSettings.Type.COMPOSITE
+import jetbrains.buildServer.configs.kotlin.FailureAction
+import jetbrains.buildServer.configs.kotlin.ParameterDisplay.NORMAL
+import jetbrains.buildServer.configs.kotlin.ParameterDisplay.PROMPT
+import jetbrains.buildServer.configs.kotlin.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.project
+import jetbrains.buildServer.configs.kotlin.triggers.schedule
+import jetbrains.buildServer.configs.kotlin.version
 
 /*
 The settings script is an entry point for defining a TeamCity
@@ -30,7 +30,7 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 'Debug' option is available in the context menu for the task.
 */
 
-version = "2021.1"
+version = "2024.12"
 
 project {
     params {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,4 +1,5 @@
 import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.BuildTypeSettings.Type.COMPOSITE
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.ParameterDisplay.NORMAL

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -214,7 +214,7 @@ project {
                     allowEmpty = false
                 )
                 password(
-                    "env.GIT_PASSWORD",
+                    "env.GIT_ACCESS_TOKEN",
                     "",
                     label = "GitHub Access Token",
                     description = "Your personal access token with repo permission",
@@ -226,11 +226,21 @@ project {
                 password("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
             }
             steps {
+                script {
+                    scriptContent = """
+                        git config credential.helper '!f() { sleep 1; echo "username=${'$'}{GIT_USERNAME}"; echo "password=${'$'}{GIT_ACCESS_TOKEN}"; }; f' 
+                    """.trimIndent()
+                }
+
                 gradle {
                     tasks = "clean final -x test"
                     buildFile = ""
                     gradleParams =
                         "-s $useGradleInternalScansServer -Prelease.scope=%releaseScope% %pluginPortalPublishingFlags%"
+                }
+
+                script {
+                    scriptContent = "git config --unset credential.helper"
                 }
             }
             dependencies {

--- a/.teamcity/settings/extensions.kt
+++ b/.teamcity/settings/extensions.kt
@@ -1,10 +1,10 @@
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.CheckoutMode
-import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
-import jetbrains.buildServer.configs.kotlin.v2019_2.ParametrizedWithType
-import jetbrains.buildServer.configs.kotlin.v2019_2.Project
-import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
-import jetbrains.buildServer.configs.kotlin.v2019_2.toId
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.CheckoutMode
+import jetbrains.buildServer.configs.kotlin.DslContext
+import jetbrains.buildServer.configs.kotlin.ParametrizedWithType
+import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.RelativeId
+import jetbrains.buildServer.configs.kotlin.toId
 
 fun BuildType.agentRequirement(os: Os) {
     requirements {


### PR DESCRIPTION
For quite some time, tagging the repository with the new release version fails when releasing the Test Retry Gradle plugin.

The reason for this is that the [nebula-release-plugin](https://github.com/nebula-plugins/nebula-release-plugin) no longer uses GrGit or JGit, and therefore nobody reads the environment variables `GIT_USERNAME` or `GRGIT_USERNAME`.

This PR configures a temporary credential helper for Git before actually releasing the plugin. This should work, but we will only know when we try it.

I've also upgraded to the latest Kotlin DSL for TeamCity, because I thought I would need it. That's probably not the case, but it still makes sense to do this, so I kept it.

Verify All build: [here](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_VerifyAll/94448310)
