### PR TITLE
Fix failing func test against latest Gradle 9 nightly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,11 +26,11 @@ tasks.named("releaseCheck") {
 }
 
 tasks.named("final") {
-    dependsOn(publishPlugins)
+    publishPlugins?.let { dependsOn(it) }
 }
 
 tasks.named("candidate") {
-    dependsOn(publishPlugins)
+    publishPlugins?.let { dependsOn(it) }
 }
 
 wrapperUpgrade {

--- a/plugin/src/test/groovy/org/gradle/testretry/KotlinDslFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/KotlinDslFuncTest.groovy
@@ -31,6 +31,14 @@ class KotlinDslFuncTest extends AbstractPluginFuncTest {
                 id("org.gradle.test-retry")
             }
 
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                testImplementation("${junit4Dependency()}")
+            }
+
             tasks.test {
                 retry {
                     maxRetries.set(2)
@@ -38,10 +46,26 @@ class KotlinDslFuncTest extends AbstractPluginFuncTest {
             }
         """
 
+        // Adding a single test because Gradle 9 fails the test task if no tests are found.
+        writeJavaTestSource(passingTest())
+
         expect:
         gradleRunner(gradleVersion).build()
 
         where:
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+
+    private static String passingTest() {
+        """
+            package acme;
+            
+            public class PassingTest {
+                @org.junit.Test
+                public void test() {
+                    // Nothing to do
+                }
+            }
+        """
     }
 }

--- a/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/ParenthesesFuncTest.groovy
@@ -58,12 +58,14 @@ class ParenthesesFuncTest extends AbstractPluginFuncTest {
         ].combinations()
     }
 
-    private static void setupJunit4Test(File buildFile) {
+    private void setupJunit4Test(File buildFile) {
         buildFile << """
             dependencies {
-                testImplementation "junit:junit:4.13.2"
+                testImplementation "${junit4Dependency()}"
                 testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
-                testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.9.2"
+                testRuntimeOnly "${junitVintageEngineDependency()}"
+                // Since Gradle 9, the JUnit platform launcher is no longer provided by Gradle. 
+                testRuntimeOnly "${junitPlatformLauncherDependency()}"
             }
 
             test {
@@ -76,11 +78,13 @@ class ParenthesesFuncTest extends AbstractPluginFuncTest {
         """
     }
 
-    private static void setupJunit5Test(File buildFile) {
+    private void setupJunit5Test(File buildFile) {
         buildFile << """
             dependencies {
-                testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
-                testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.2'
+                testImplementation "${jupiterDependency()}"
+                testImplementation "${jupiterParamsDependency()}"
+                // Since Gradle 9, the JUnit platform launcher is no longer provided by Gradle. 
+                testRuntimeOnly "${junitPlatformLauncherDependency()}"
             }
 
             test {

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4ViaJUnitVintageFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit4ViaJUnitVintageFuncTest.groovy
@@ -43,6 +43,8 @@ class JUnit4ViaJUnitVintageFuncTest extends JUnit4FuncTest {
                 testImplementation "${junit4Dependency()}"
                 testImplementation "${jupiterApiDependency()}"
                 testRuntimeOnly "${junitVintageEngineDependency()}"
+                // Since Gradle 9, the JUnit platform launcher is no longer provided by Gradle. 
+                testRuntimeOnly "${junitPlatformLauncherDependency()}"
             }
 
             test {

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock2FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/Spock2FuncTest.groovy
@@ -44,6 +44,8 @@ class Spock2FuncTest extends SpockBaseJunit5FuncTest {
         return """
             dependencies {
                 implementation '${spock2Dependency()}'
+                // Since Gradle 9, the JUnit platform launcher is no longer provided by Gradle. 
+                testRuntimeOnly '${junitPlatformLauncherDependency()}'
             }
             test {
                 useJUnitPlatform()

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockViaJUnitVintageFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/SpockViaJUnitVintageFuncTest.groovy
@@ -40,6 +40,8 @@ class SpockViaJUnitVintageFuncTest extends SpockBaseJunit5FuncTest {
                 testImplementation "${spock1Dependency()}"
                 testImplementation "${jupiterApiDependency()}"
                 testRuntimeOnly "${junitVintageEngineDependency()}"
+                // Since Gradle 9, the JUnit platform launcher is no longer provided by Gradle. 
+                testRuntimeOnly "${junitPlatformLauncherDependency()}"
             }
 
             test {

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGViaJUnitEngineFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/TestNGViaJUnitEngineFuncTest.groovy
@@ -42,6 +42,8 @@ class TestNGViaJUnitEngineFuncTest extends BaseTestNGFuncTest {
             dependencies {
                 testImplementation 'org.testng:testng:7.5'
                 testRuntimeOnly 'org.junit.support:testng-engine:1.0.5'
+                // Since Gradle 9, the JUnit platform launcher is no longer provided by Gradle. 
+                testRuntimeOnly '${junitPlatformLauncherDependency()}'
             }
             test {
                 useJUnitPlatform()

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/UnsupportedTestFrameworkFuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/UnsupportedTestFrameworkFuncTest.groovy
@@ -22,10 +22,12 @@ import org.gradle.util.GradleVersion
 class UnsupportedTestFrameworkFuncTest extends AbstractFrameworkFuncTest {
 
     private static final GradleVersion GRADLE_7_999 = GradleVersion.version("7.999")
+    private static final GradleVersion GRADLE_8_999 = GradleVersion.version("8.999")
 
     def "logs warning if test framework is unsupported"(String gradleVersion) {
         given:
-        def gradle8OrAbove = GradleVersion.version(gradleVersion) > GRADLE_7_999
+        def version = GradleVersion.version(gradleVersion)
+        def isGradle8 = version > GRADLE_7_999 && version < GRADLE_8_999
 
         buildFile << """
             test.retry.maxRetries = 2
@@ -40,7 +42,7 @@ class UnsupportedTestFrameworkFuncTest extends AbstractFrameworkFuncTest {
                     this.delegate = new org.gradle.api.internal.tasks.testing.junit.JUnitTestFramework(
                         testTask,
                         testFilter,
-                        ${gradle8OrAbove ? 'true' : ''}
+                        ${isGradle8 ? 'true' : ''}
                     )
                 }
             }


### PR DESCRIPTION
Changes in the Gradle nightlies make some CV func tests fail since Apr 12 (see [here](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_CrossVersionTestGradleNightliesLinuxJava18?branch=%3Cdefault%3E&buildTypeTab=overview#all-projects)). This PR aims to fix those failures against Gradle 9 nightly.

CV Gradle Nightlies Linux - Java 1.8: [here](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_CrossVersionTestGradleNightliesLinuxJava18/97859870)
Verify all: [here](https://builds.gradle.org/buildConfiguration/OpenSourceProjects_GradleTestRetryPlugin_null_VerifyAll/97859881)