### PR TITLE
Use JDK17 to run tests against Gradle 9.0 nightlies

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -36,6 +36,7 @@ version = "2024.12"
 project {
     params {
         java8Home(Os.linux)
+        java17Home(Os.linux)
         text("systemProp.org.gradle.internal.publish.checksums.insecure", "true")
     }
 
@@ -74,7 +75,7 @@ project {
             gradle {
                 tasks = "clean testGradleNightlies"
                 buildFile = ""
-                gradleParams = "-s $useGradleInternalScansServer $buildCacheSetup"
+                gradleParams = "-s $useGradleInternalScansServer $buildCacheSetup -PjavaToolchainVersion=17"
             }
         }
 

--- a/.teamcity/settings/extensions.kt
+++ b/.teamcity/settings/extensions.kt
@@ -19,7 +19,11 @@ fun BuildType.notEc2Requirement() {
 }
 
 fun ParametrizedWithType.java8Home(os: Os) {
-    param("env.JAVA_HOME", "%${os.name}.java8.oracle.64bit%")
+    param("env.JDK8", "%${os.name}.java8.oracle.64bit%")
+}
+
+fun ParametrizedWithType.java17Home(os: Os) {
+    param("env.JDK17", "%${os.name}.java17.openjdk.64bit%")
 }
 
 const val useGradleInternalScansServer = "-I gradle/init-scripts/build-scan.init.gradle.kts"
@@ -52,6 +56,7 @@ fun Project.buildType(buildTypeName: String, init: BuildType.() -> Unit): BuildT
 
         params {
             java8Home(Os.linux)
+            java17Home(Os.linux)
 
             param("env.GRADLE_CACHE_REMOTE_URL", "%gradle.cache.remote.url%")
             param("env.GRADLE_CACHE_REMOTE_USERNAME", "%gradle.cache.remote.username%")


### PR DESCRIPTION
Gradle 9.0 requires at least JDK 17 to execute the test builds. This change uses the existing property we have in place to overwrite the Java version used for compilation and tests and sets it to 17 when tests use Gradle nightlies.