### PR TITLE
Specify env variables to use for the toolchain lookup

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: "Setup Build Environment"
+      uses: ./.github/actions/setup-environment
+
     - name: Setup Git user
       shell: bash
       run: |

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -70,7 +70,7 @@ project {
         }
     }
 
-    val nightliesTestLinux = buildType("CrossVersionTest Gradle Nightlies Linux - Java 1.8") {
+    val nightliesTestLinux = buildType("CrossVersionTest Gradle Nightlies Linux - Java 17") {
         steps {
             gradle {
                 tasks = "clean testGradleNightlies"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.java.installations.auto-detect=false
+org.gradle.java.installations.auto-download=false
+org.gradle.java.installations.fromEnv=JDK8,JDK17
 systemProp.org.gradle.kotlin.dsl.caching.buildcache=true
 systemProp.scan.capture-file-fingerprints=true
 systemProp.org.gradle.groovy.compilation.avoidance=true


### PR DESCRIPTION
My previous changes made in https://github.com/gradle/test-retry-gradle-plugin/pull/405 were not enough as I assumed that `JDK*` env variables are considered for auto-detection. But it is not the case and they need to be explicitly specified.