### PR TITLE
Fix Gradle release nightlies CI job

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -73,9 +73,9 @@ project {
     val nightliesTestLinux = buildType("CrossVersionTest Gradle Nightlies Linux - Java 17") {
         steps {
             gradle {
-                tasks = "clean testGradle8Nightlies"
+                tasks = "clean testGradleReleaseNightlies"
                 buildFile = ""
-                gradleParams = "-s $useGradleInternalScansServer $buildCacheSetup"
+                gradleParams = "-s $useGradleInternalScansServer $buildCacheSetup -PjavaToolchainVersion=17"
             }
             gradle {
                 tasks = "clean testGradleNightlies"

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -180,7 +180,7 @@ listOf(5, 6, 7, 8).map { gradleMajorVersion ->
     }
 }
 
-tasks.register<Test>("testGradle8Nightlies") {
+tasks.register<Test>("testGradleReleaseNightlies") {
     jvmArgumentProviders.add(GradleVersionsCommandLineArgumentProvider(GradleVersionData::getLatestReleaseNightly))
 }
 


### PR DESCRIPTION
Since quite some time `testGradle8Nightlies` started using the Gradle 9.0 snapshots instead of 8.x snapshots. The `testGradleNightlies` now uses Gradle 9.1. Since Gradle 9.x requires Java 17 to run builds, we need to apply the same pattern that we did for the `testGradleNightlies` CI job