### PR TITLE
Fix the check for verifying that the published artifact was compiled with Java 8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
 plugins {
     id("nebula.release") version "20.2.0"
     id("org.gradle.wrapper-upgrade") version "0.12"
@@ -17,10 +20,28 @@ evaluationDependsOn("plugin")
 
 val publishPlugins = tasks.findByPath(":plugin:publishPlugins")
 
+fun runCommand(vararg command: String): String {
+    val process = ProcessBuilder(command.toList()).start()
+    val reader = BufferedReader(InputStreamReader(process.inputStream))
+    val output = StringBuilder()
+    var line: String?
+    while (reader.readLine().also { line = it } != null) {
+        output.append(line).append("\n")
+    }
+    process.waitFor()
+    return output.toString()
+}
+
+val jar = tasks.getByPath(":plugin:shadowJar")
 tasks.named("releaseCheck") {
+    inputs.files(jar.outputs.files)
     doFirst {
-        if (!JavaVersion.current().isJava8) {
-            throw GradleException("Plugin releases should use Java 8, but used ${JavaVersion.current()} instead.")
+        val jarPath = jar.outputs.files.singleFile.path
+        val classFileInfo = runCommand("javap", "-cp", jarPath, "-v", "org.gradle.testretry.TestRetryPlugin")
+        val classFileVersion = requireNotNull("major version: (\\d+)".toRegex().find(classFileInfo)).groupValues.last().toInt()
+        val javaVersionForCompilation = JavaVersion.forClassVersion(classFileVersion)
+        if (!javaVersionForCompilation.isJava8) {
+            throw GradleException("Plugin releases should use Java 8, but was $javaVersionForCompilation")
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ val publishPlugins = tasks.findByPath(":plugin:publishPlugins")
 tasks.named("releaseCheck") {
     doFirst {
         if (!JavaVersion.current().isJava8) {
-            throw GradleException("Plugin releases should use Java 8.")
+            throw GradleException("Plugin releases should use Java 8, but used ${JavaVersion.current()} instead.")
         }
     }
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.google.gson.Gson
 import org.gradle.testretry.build.GradleVersionData
 import org.gradle.testretry.build.GradleVersionsCommandLineArgumentProvider
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URL
 
@@ -40,7 +41,7 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions.jvmTarget = "1.8"
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
 }
 
 val plugin: Configuration by configurations.creating {


### PR DESCRIPTION
Previous check was verifying that the `releaseCheck` task was running with Java 8, not necessarily that the published artifact was compiled with Java 8. By default, tasks will use Java 21 as it is the default JDK on our CI agents, and only compilation tasks will use 8 through Gradle toolchains.Signed-off-by: Pavlo Shevchenko <pshevchenko@gradle.com>