### PR TITLE
Add missing test task for Gradle 9 releases

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -174,7 +174,7 @@ tasks.withType<Test> {
     systemProperty("testNgVersion", libs.versions.testNg.get())
 }
 
-listOf(5, 6, 7, 8).map { gradleMajorVersion ->
+listOf(5, 6, 7, 8, 9).map { gradleMajorVersion ->
     tasks.register<Test>("testGradle${gradleMajorVersion}Releases") {
         jvmArgumentProviders.add(GradleVersionsCommandLineArgumentProvider {
             GradleVersionData.getReleasedVersions(


### PR DESCRIPTION
In the last team time, we added a CI job to test Gradle 9 releases, but we forgot to add a Gradle task that the CI job will invoke.