### PR TITLE
Fix bug in TestsReader

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/testsreader/TestsReader.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/testsreader/TestsReader.java
@@ -97,7 +97,7 @@ public final class TestsReader {
             if (file.isDirectory()) {
                 File classFile = new File(file, classFileName);
                 if (classFile.exists()) {
-                    return Optional.of(visitClassFile(classFile, factory.get()));
+                    return Optional.ofNullable(visitClassFile(classFile, factory.get()));
                 } else {
                     continue;
                 }


### PR DESCRIPTION
Use `Optional.ofNullable` to avoid throwing an NPE when a class file can't be read.

`visitClassFile` is annotated with `@Nullable`, and reading the code I can see that it returns null if it's unable to parse the class file. We ran into this issue when running tests on JDK 25. I guess it's indicative that Java 25 class files can't be parsed, but the intent of the code is to log a warning and proceed as far as I can tell.