### PR TITLE
Don't retry empty class names

### DIFF
--- a/plugin/src/main/java/org/gradle/testretry/internal/filter/RetryFilter.java
+++ b/plugin/src/main/java/org/gradle/testretry/internal/filter/RetryFilter.java
@@ -64,10 +64,12 @@ public class RetryFilter {
 
         if (!excludeAnnotationClasses.isEmpty()) {
             annotations = annotations == null ? annotationInspector.getClassAnnotations(className) : annotations;
-            return !anyMatch(excludeAnnotationClasses, annotations);
+            if (!anyMatch(excludeAnnotationClasses, annotations)) {
+                return false;
+            }
         }
 
-        return true;
+        return !className.isEmpty();
     }
 
     private static boolean anyMatch(Set<GlobPattern> patterns, String string) {

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
@@ -520,6 +520,49 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
         gradleVersion << GRADLE_VERSIONS_UNDER_TEST
     }
 
+    def "handles setup failure caused by errors in discovery (gradle version #gradleVersion)"() {
+        given:
+        buildFile << """
+            test.retry.maxRetries = 2
+            
+            dependencies {
+                testCompileOnly gradleApi()
+            }
+        """
+
+        and:
+        writeJavaTestSource """
+            package acme;
+
+            import org.gradle.api.Task;
+
+            public class DiscoveryClassLoadingErrorTest {
+                // Add a reliance on class that won't be present at runtime,
+                // but also won't fail immediately at link time.
+                // It needs to fail specifically during discovery.
+                public Task dummyTaskMethod() {
+                    return null;
+                }
+
+                @org.junit.jupiter.api.Test
+                public void unimportantTestMethod() {
+                }
+            }
+        """
+
+        when:
+        def result = gradleRunner(gradleVersion).buildAndFail()
+
+        then:
+        with(result.output) {
+            it.contains("> There were failing tests.")
+            it.count("${beforeClassErrorTestMethodName(gradleVersion)} FAILED") == 3
+        }
+
+        where:
+        gradleVersion << GRADLE_VERSIONS_UNDER_TEST
+    }
+
     def "can rerun the whole class in JUnit5's Suite via className (gradle version #gradleVersion)"() {
         given:
         buildFile << """

--- a/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/testretry/testframework/JUnit5FuncTest.groovy
@@ -554,9 +554,12 @@ class JUnit5FuncTest extends AbstractFrameworkFuncTest {
         def result = gradleRunner(gradleVersion).buildAndFail()
 
         then:
+        // In 9.4.0 we start to properly report discovery errors as part of "JUnit Jupiter" instead of the class(es)
+        // we were trying to run. This means we don't try to re-run it because there's no associated class name.
+        def discoveryErrorIsClassifiedUnderRootClass = GradleVersion.version(gradleVersion) <= GradleVersion.version("9.3.1")
         with(result.output) {
             it.contains("> There were failing tests.")
-            it.count("${beforeClassErrorTestMethodName(gradleVersion)} FAILED") == 3
+            it.count("${beforeClassErrorTestMethodName(gradleVersion)} FAILED") == (discoveryErrorIsClassifiedUnderRootClass ? 3 : 1)
         }
 
         where:


### PR DESCRIPTION
These aren't valid for filters. This may cause issues for non-class-based testing, but that will need a much more thorough rewrite of the logic in this plugin.

Fixes https://github.com/gradle/test-retry-gradle-plugin/issues/500