### PR TITLE
fix: declare the CC compatibility

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.google.gson.Gson
+import org.gradle.plugin.compatibility.compatibility
 import org.gradle.testretry.build.GradleVersionData
 import org.gradle.testretry.build.GradleVersionsCommandLineArgumentProvider
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
@@ -105,6 +106,11 @@ gradlePlugin {
             description = project.description
             implementationClass = "org.gradle.testretry.TestRetryPlugin"
             tags.addAll("test", "flaky")
+            compatibility {
+                features {
+                    configurationCache = true
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The publication fails with 

```
Execution failed for task ':plugin:publishPlugins'.
06:56:53   > Failed to post to server.
06:56:53     Server responded with:
06:56:53     The following feature compatibility declarations were present in the previous version but are missing in the new version: 'configuration-cache'. Feature compatibility declarations cannot be removed once they have been added.
```

This is because the Gradle-owned plugins were retrospectively marked as CC-compatible without updating the publication code.