### PR TITLE
Update Publish build agent requirement

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -207,7 +207,7 @@ project {
                 withPendingChangesOnly = false
             }
 
-            notEc2Requirement()
+            releaseRequirement()
         }
 
         buildType("Development") {

--- a/.teamcity/settings/extensions.kt
+++ b/.teamcity/settings/extensions.kt
@@ -12,9 +12,9 @@ fun BuildType.agentRequirement(os: Os) {
     }
 }
 
-fun BuildType.notEc2Requirement() {
+fun BuildType.releaseRequirement() {
     requirements {
-        doesNotContain("teamcity.agent.name", "ec2")
+        contains("teamcity.agent.name", "release")
     }
 }
 


### PR DESCRIPTION
## What changed

Updates the agent requirement on the **Release → Publish** build to match the new agent pool structure.

- Replaced `doesNotContain("teamcity.agent.name", "ec2")` with `contains("teamcity.agent.name", "release")`.
- Renamed the helper `notEc2Requirement()` → `releaseRequirement()` so the name reflects the actual behavior.

## Effect

The `Publish` build now targets agents whose name **contains `release`**, instead of merely excluding `ec2` agents.
