### PR TITLE
Update signing configuration for PGP subkey

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -176,6 +176,7 @@ project {
             params {
                 param("env.ORG_GRADLE_PROJECT_artifactoryUsername", "%artifactoryUsername%")
                 param("env.ORG_GRADLE_PROJECT_artifactoryPassword", "%artifactoryPassword%")
+                param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
                 password("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
                 password("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
             }
@@ -216,6 +217,7 @@ project {
             params {
                 param("env.GRADLE_PUBLISH_KEY", "%development.plugin.portal.publish.key%")
                 password("env.GRADLE_PUBLISH_SECRET", "%development.plugin.portal.publish.secret%", display = NORMAL)
+                param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
                 password("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
                 password("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
             }
@@ -260,6 +262,7 @@ project {
                 )
                 param("env.GRADLE_PUBLISH_KEY", "%plugin.portal.publish.key%")
                 password("env.GRADLE_PUBLISH_SECRET", "%plugin.portal.publish.secret%", display = NORMAL)
+                param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
                 password("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
                 password("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
             }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -161,7 +161,12 @@ publishing {
 }
 
 signing {
-    useInMemoryPgpKeys(System.getenv("PGP_SIGNING_KEY"), System.getenv("PGP_SIGNING_KEY_PASSPHRASE"))
+    useInMemoryPgpKeys(
+        // Key ID required when signing with a subkey
+        System.getenv("PGP_SIGNING_KEY_ID"),
+        System.getenv("PGP_SIGNING_KEY"),
+        System.getenv("PGP_SIGNING_KEY_PASSPHRASE")
+    )
 }
 
 tasks.withType<Sign>().configureEach {


### PR DESCRIPTION
After the move to a signing subkey following the August 14 security incident, `useInMemoryPgpKeys` needs the key ID as its first argument — without it the signing plugin falls back to the primary key.

This adds the key ID to the `signing {}` block and makes the publishing build configuration pass it as `env.PGP_SIGNING_KEY_ID`, matching what was already done in gradle/gradle#38874 and the other Gradle-org repos.

The `pgpSigningKeyId` parameter now exists on the `OpenSourceProjects` TeamCity project, so no new secret is needed.

Docs: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:subkeys
Part of gradle/gradle-private#5321